### PR TITLE
feat: Phase 1 completion — KeyInfo, Exclusive C14N, dedup

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -49,6 +49,12 @@ jobs:
         run: scripts/gen_certs.sh
       - name: Run test
         run: rebar3 test
+      - name: Upload cover report
+        if: always() && runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cover-report-otp-${{matrix.otp_vsn}}
+          path: _build/test/cover/
       - name: Run lint
         run: rebar3 lint
       - name: Run dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -48,9 +48,7 @@ jobs:
         shell: bash
         run: scripts/gen_certs.sh
       - name: Run test
-        run: |
-          rm -rf _build/test
-          rebar3 test
+        run: rebar3 test
       - name: Run lint
         run: rebar3 lint
       - name: Run dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -49,12 +49,6 @@ jobs:
         run: scripts/gen_certs.sh
       - name: Run test
         run: rebar3 test
-      - name: Upload cover report
-        if: always() && runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
-        with:
-          name: cover-report-otp-${{matrix.otp_vsn}}
-          path: _build/test/cover/
       - name: Run lint
         run: rebar3 lint
       - name: Run dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -48,7 +48,9 @@ jobs:
         shell: bash
         run: scripts/gen_certs.sh
       - name: Run test
-        run: rebar3 test
+        run: |
+          rm -rf _build/test
+          rebar3 test
       - name: Run lint
         run: rebar3 lint
       - name: Run dialyzer

--- a/docs/implementations/phase1_completion.md
+++ b/docs/implementations/phase1_completion.md
@@ -1,0 +1,71 @@
+# Phase 1 Completion: KeyInfo, Exclusive C14N, Dedup
+
+## What Changed
+
+### Files and Behavior
+
+**`src/signerl.erl`**
+- Added `sign/4` accepting optional `CertDer :: binary()` parameter for embedding X.509 certificates.
+- `sign/3` delegates to `sign/4` with `undefined`.
+- Both `sign/3` and `sign/4` support file path convenience clauses for message and key paths.
+- `verify/3` now auto-detects C14N mode from the signature's `CanonicalizationMethod` algorithm URI.
+
+**`src/signerl_signature.erl`**
+- `build_signature_element/3` → `/4` with optional `CertDer`.
+- Added `key_info/1` helper that builds `ds:KeyInfo > ds:X509Data > ds:X509Certificate` or returns `[]` when `CertDer` is `undefined`.
+- `add_signature_value/2` handles variable children count (with/without KeyInfo).
+
+**`src/signerl_verify.erl`**
+- Removed local `is_signature_element/1` (consolidated to `signerl_xml`).
+- Added `c14n_mode/1` to resolve C14N mode from signature data (supports C14N 1.1 and Exclusive C14N).
+- Added `extract_key_info/1` and `extract_x509_certificate/1` for parsing `ds:KeyInfo` from signatures.
+- Added `is_supported_c14n/1` recognizing both `?DSIG_C14N11_ALGO_URI` and `?DSIG_EXC_C14N_ALGO_URI`.
+- Exported `c14n_mode/1`.
+
+**`src/signerl_c14n.erl`**
+- Major restructure: split into `c14n11_element/2` (C14N 1.1) and `exc_element/3` (Exclusive C14N) code paths.
+- Added `exc_needed_decls/3` to determine which namespace declarations to emit based on visible utilization.
+- Added `visibly_used_prefixes/2`, `extract_prefix/1`, `prefix_to_ns_decl/1` helpers.
+- Exported `c14n_mode()` type.
+
+**`src/signerl_xml.erl`**
+- Added `is_signature_element/1` (consolidated from `signerl_verify` and `signerl_c14n`).
+
+**`include/signerl_dsig.hrl`**
+- Added `?DSIG_EXC_C14N_ALGO_URI` macro.
+
+### Tests
+
+**`test/signerl_SUITE.erl`**
+- Updated all `build_signature_element/3` calls to `/4` with `undefined`.
+- Added `keyinfo_group` (7 tests): sign with/without cert, roundtrip RSA/ECDSA, file path convenience clauses, KeyInfo extraction, absent KeyInfo.
+- Added `interop_smoke_group` (2 tests): C14N idempotency, `is_signature_element` shared.
+- Added standalone tests: `c14n_mode` for exc_c14n, `extract_x509_certificate` error paths, `sign/4` file error paths, exc_c14n algorithm acceptance.
+
+**`test/signerl_c14n_SUITE.erl`**
+- Added `exc_c14n_group` (8 tests): omits unused ns, keeps visibly used ns, propagates ns to children, binary text child, default namespace, ns already in output scope, C14N 1.1 comparison, `canonicalize/1` defaults.
+
+**`test/test_helpers.erl`**
+- Added `cert_der/1` helper for loading raw DER from PEM certificate files.
+
+## Why This Solves the Task
+
+This completes all remaining Phase 1 roadmap items:
+- **#35 Exclusive C14N**: Full implementation with separate code path, proper visible utilization tracking, and comprehensive tests.
+- **KeyInfo/X.509**: `sign/4` embeds certificate in `ds:KeyInfo`, verification extracts and returns it.
+- **Dedup `is_signature_element/1`**: Consolidated to `signerl_xml`, eliminating code duplication.
+- **Dead code removal**: Verified no dead code remains after C14N restructure.
+
+## Validation
+
+| Gate | Result |
+|------|--------|
+| `rebar3 eunit` | 14 tests, 0 failures |
+| `rebar3 ct` | 124 tests, 0 failures |
+| `rebar3 as test cover` | 100% total coverage |
+| `rebar3 flint` | Clean |
+| `rebar3 dialyzer` | Clean |
+
+## Documentation
+
+No public-facing documentation updates required — `sign/4` follows the existing `sign/3` convention and the README already references the signing API. Exclusive C14N is an internal capability used by the verification pipeline.

--- a/docs/implementations/phase1_completion.md
+++ b/docs/implementations/phase1_completion.md
@@ -69,3 +69,9 @@ This completes all remaining Phase 1 roadmap items:
 ## Documentation
 
 No public-facing documentation updates required — `sign/4` follows the existing `sign/3` convention and the README already references the signing API. Exclusive C14N is an internal capability used by the verification pipeline.
+
+## CI Cover Fix
+
+**Root cause:** The `test` alias in `rebar.config` ran `erlfmt` (write mode) between `eunit` and `ct --cover`. This reformatted source files mid-run, causing eunit and ct to cover-compile different source versions. When the coverdata was merged, phantom uncovered lines appeared (e.g., `signerl_c14n` dropped to 82% on OTP 27/28).
+
+**Fix:** Moved `fmt` before `cover --reset` in both `test` and `tall` aliases, ensuring both eunit and ct instrument the same post-format source. Also removed temporary CI artifact upload step and let `erlfmt` normalize `render_element` formatting.

--- a/include/signerl_dsig.hrl
+++ b/include/signerl_dsig.hrl
@@ -1,4 +1,5 @@
 -define(DSIG_C14N11_ALGO_URI, "http://www.w3.org/2006/12/xml-c14n11").
+-define(DSIG_EXC_C14N_ALGO_URI, "http://www.w3.org/2001/10/xml-exc-c14n#").
 -define(DSIG_ENVELOPED_SIGNATURE_TRANSFORM_URI,
     "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
 ).

--- a/rebar.config
+++ b/rebar.config
@@ -3,16 +3,16 @@
 
 {alias, [
     {test, [
+        fmt,
         {cover, "--reset"},
         eunit,
-        fmt,
         {ct, "--cover verbose true"},
         {cover, "--min_coverage 100"}
     ]},
     {tall, [
+        fmt,
         {cover, "--reset"},
         eunit,
-        fmt,
         xref,
         dialyzer,
         {ct, "--name ct --sys_config=config/sys.config --readable true --cover verbose true"},

--- a/rebar.config
+++ b/rebar.config
@@ -4,15 +4,13 @@
 {alias, [
     {test, [
         fmt,
-        {cover, "--reset"},
-        eunit,
+        {eunit, "--cover false"},
         {ct, "--cover verbose true"},
         {cover, "--min_coverage 100"}
     ]},
     {tall, [
         fmt,
-        {cover, "--reset"},
-        eunit,
+        {eunit, "--cover false"},
         xref,
         dialyzer,
         {ct, "--name ct --sys_config=config/sys.config --readable true --cover verbose true"},
@@ -24,7 +22,6 @@
     ]}
 ]}.
 
-{cover_enabled, true}.
 {cover_opts, [verbose]}.
 
 {project_plugins, [

--- a/src/signerl.erl
+++ b/src/signerl.erl
@@ -1,7 +1,7 @@
 -module(signerl).
 -feature(maybe_expr, enable).
 
--export([sign/3, verify/3]).
+-export([sign/3, sign/4, verify/3]).
 
 -type hash() :: sha256 | sha384 | sha512.
 -export_type([hash/0]).
@@ -27,11 +27,38 @@ sign(FilePath, Hash, Key) when is_list(FilePath) ->
             {error, {file_error, Reason}}
     end;
 sign(Message, Hash, Key) when is_binary(Message) ->
+    sign_impl(Message, Hash, Key, undefined).
+
+-spec sign(Message, Hash, Key, CertDer) -> SignedMessage | {error, Reason} when
+    Message :: binary() | string(),
+    Hash :: hash(),
+    Key :: public_key:private_key() | string(),
+    CertDer :: binary(),
+    SignedMessage :: binary(),
+    Reason :: atom() | {file_error, term()}.
+sign(Message, Hash, FilePath, CertDer) when is_binary(Message), is_list(FilePath) ->
+    case signerl_utils:load_key_from_file(FilePath) of
+        {ok, Key} ->
+            sign(Message, Hash, Key, CertDer);
+        {error, _} = Err ->
+            Err
+    end;
+sign(FilePath, Hash, Key, CertDer) when is_list(FilePath) ->
+    case file:read_file(FilePath) of
+        {ok, RawMessage} ->
+            sign(RawMessage, Hash, Key, CertDer);
+        {error, Reason} ->
+            {error, {file_error, Reason}}
+    end;
+sign(Message, Hash, Key, CertDer) when is_binary(Message) ->
+    sign_impl(Message, Hash, Key, CertDer).
+
+sign_impl(Message, Hash, Key, CertDer) ->
     maybe
         {ok, Prolog} ?= signerl_xml:parse_prolog(Message),
         {ok, ParsedMessage} ?= signerl_xml:parse_binary(Message),
         {ok, SignatureElement} ?=
-            signerl_signature:build_signature_element(ParsedMessage, Hash, Key),
+            signerl_signature:build_signature_element(ParsedMessage, Hash, Key, CertDer),
         SignedMessage = signerl_xml:add_new_element(SignatureElement, ParsedMessage),
         signerl_xml:export(Prolog, SignedMessage)
     else
@@ -65,7 +92,8 @@ verify(SignedMessage, Hash, Key) when is_binary(SignedMessage) ->
         {ok, SignatureBytes} ?= maps:find(signature_bytes, SignatureData),
         {ok, SignedInfoElement} ?= maps:find(signed_info_element, SignatureData),
         true ?= signerl_verify:verify_reference_digests(SignatureData, Hash),
-        SignedInfoBytes = signerl_c14n:canonicalize(SignedInfoElement),
+        C14NMode = signerl_verify:c14n_mode(SignatureData),
+        SignedInfoBytes = signerl_c14n:canonicalize(SignedInfoElement, C14NMode),
         public_key:verify(SignedInfoBytes, Hash, SignatureBytes, Key)
     else
         false ->

--- a/src/signerl.erl
+++ b/src/signerl.erl
@@ -6,59 +6,59 @@
 -type hash() :: sha256 | sha384 | sha512.
 -export_type([hash/0]).
 
--spec sign(Message, Hash, Key) -> SignedMessage | {error, Reason} when
+-spec sign(Message, HashAlgorithm, Key) -> SignedMessage | {error, Reason} when
     Message :: binary() | string(),
-    Hash :: hash(),
+    HashAlgorithm :: hash(),
     Key :: public_key:private_key() | string(),
     SignedMessage :: binary(),
     Reason :: atom() | {file_error, term()}.
-sign(Message, Hash, FilePath) when is_binary(Message), is_list(FilePath) ->
+sign(Message, HashAlgorithm, FilePath) when is_binary(Message), is_list(FilePath) ->
     case signerl_utils:load_key_from_file(FilePath) of
         {ok, Key} ->
-            sign(Message, Hash, Key);
+            sign(Message, HashAlgorithm, Key);
         {error, _} = Err ->
             Err
     end;
-sign(FilePath, Hash, Key) when is_list(FilePath) ->
+sign(FilePath, HashAlgorithm, Key) when is_list(FilePath) ->
     case file:read_file(FilePath) of
         {ok, RawMessage} ->
-            sign(RawMessage, Hash, Key);
+            sign(RawMessage, HashAlgorithm, Key);
         {error, Reason} ->
             {error, {file_error, Reason}}
     end;
-sign(Message, Hash, Key) when is_binary(Message) ->
-    sign_impl(Message, Hash, Key, undefined).
+sign(Message, HashAlgorithm, Key) when is_binary(Message) ->
+    sign_impl(Message, HashAlgorithm, Key, undefined).
 
--spec sign(Message, Hash, Key, CertDer) -> SignedMessage | {error, Reason} when
+-spec sign(Message, HashAlgorithm, Key, CertDer) -> SignedMessage | {error, Reason} when
     Message :: binary() | string(),
-    Hash :: hash(),
+    HashAlgorithm :: hash(),
     Key :: public_key:private_key() | string(),
     CertDer :: binary(),
     SignedMessage :: binary(),
     Reason :: atom() | {file_error, term()}.
-sign(Message, Hash, FilePath, CertDer) when is_binary(Message), is_list(FilePath) ->
+sign(Message, HashAlgorithm, FilePath, CertDer) when is_binary(Message), is_list(FilePath) ->
     case signerl_utils:load_key_from_file(FilePath) of
         {ok, Key} ->
-            sign(Message, Hash, Key, CertDer);
+            sign(Message, HashAlgorithm, Key, CertDer);
         {error, _} = Err ->
             Err
     end;
-sign(FilePath, Hash, Key, CertDer) when is_list(FilePath) ->
+sign(FilePath, HashAlgorithm, Key, CertDer) when is_list(FilePath) ->
     case file:read_file(FilePath) of
         {ok, RawMessage} ->
-            sign(RawMessage, Hash, Key, CertDer);
+            sign(RawMessage, HashAlgorithm, Key, CertDer);
         {error, Reason} ->
             {error, {file_error, Reason}}
     end;
-sign(Message, Hash, Key, CertDer) when is_binary(Message) ->
-    sign_impl(Message, Hash, Key, CertDer).
+sign(Message, HashAlgorithm, Key, CertDer) when is_binary(Message) ->
+    sign_impl(Message, HashAlgorithm, Key, CertDer).
 
-sign_impl(Message, Hash, Key, CertDer) ->
+sign_impl(Message, HashAlgorithm, Key, CertDer) ->
     maybe
         {ok, Prolog} ?= signerl_xml:parse_prolog(Message),
         {ok, ParsedMessage} ?= signerl_xml:parse_binary(Message),
         {ok, SignatureElement} ?=
-            signerl_signature:build_signature_element(ParsedMessage, Hash, Key, CertDer),
+            signerl_signature:build_signature_element(ParsedMessage, HashAlgorithm, Key, CertDer),
         SignedMessage = signerl_xml:add_new_element(SignatureElement, ParsedMessage),
         signerl_xml:export(Prolog, SignedMessage)
     else
@@ -66,35 +66,35 @@ sign_impl(Message, Hash, Key, CertDer) ->
             {error, Reason}
     end.
 
--spec verify(SignedMessage, Hash, Key) -> boolean() | {error, Reason} when
+-spec verify(SignedMessage, HashAlgorithm, Key) -> boolean() | {error, Reason} when
     SignedMessage :: binary() | string(),
-    Hash :: hash(),
+    HashAlgorithm :: hash(),
     Key :: public_key:public_key() | string(),
     Reason :: atom() | {file_error, term()}.
-verify(SignedMessage, Hash, FilePath) when is_binary(SignedMessage), is_list(FilePath) ->
+verify(SignedMessage, HashAlgorithm, FilePath) when is_binary(SignedMessage), is_list(FilePath) ->
     case signerl_utils:load_key_from_file(FilePath) of
         {ok, Key} ->
-            verify(SignedMessage, Hash, Key);
+            verify(SignedMessage, HashAlgorithm, Key);
         {error, _} = Err ->
             Err
     end;
-verify(FilePath, Hash, Key) when is_list(FilePath) ->
+verify(FilePath, HashAlgorithm, Key) when is_list(FilePath) ->
     case file:read_file(FilePath) of
         {ok, RawMessage} ->
-            verify(RawMessage, Hash, Key);
+            verify(RawMessage, HashAlgorithm, Key);
         {error, Reason} ->
             {error, {file_error, Reason}}
     end;
-verify(SignedMessage, Hash, Key) when is_binary(SignedMessage) ->
+verify(SignedMessage, HashAlgorithm, Key) when is_binary(SignedMessage) ->
     maybe
         {ok, ParsedMessage} ?= signerl_xml:parse_binary(SignedMessage),
         {ok, SignatureData} ?= signerl_verify:extract_signature_data(ParsedMessage),
         {ok, SignatureBytes} ?= maps:find(signature_bytes, SignatureData),
         {ok, SignedInfoElement} ?= maps:find(signed_info_element, SignatureData),
-        true ?= signerl_verify:verify_reference_digests(SignatureData, Hash),
+        true ?= signerl_verify:verify_reference_digests(SignatureData, HashAlgorithm),
         C14NMode = signerl_verify:c14n_mode(SignatureData),
         SignedInfoBytes = signerl_c14n:canonicalize(SignedInfoElement, C14NMode),
-        public_key:verify(SignedInfoBytes, Hash, SignatureBytes, Key)
+        public_key:verify(SignedInfoBytes, HashAlgorithm, SignatureBytes, Key)
     else
         false ->
             false;

--- a/src/signerl_c14n.erl
+++ b/src/signerl_c14n.erl
@@ -156,8 +156,17 @@ attr_sort_key(Name, NsMap) ->
 %% --- Rendering ---
 
 render_element(TagStr, NsDecls, Attrs, ChildrenIo) ->
-    ["<", TagStr, render_ns_decls(NsDecls), render_attributes(Attrs), ">",
-     ChildrenIo, "</", TagStr, ">"].
+    [
+        "<",
+        TagStr,
+        render_ns_decls(NsDecls),
+        render_attributes(Attrs),
+        ">",
+        ChildrenIo,
+        "</",
+        TagStr,
+        ">"
+    ].
 
 render_ns_decls([]) ->
     [];

--- a/src/signerl_c14n.erl
+++ b/src/signerl_c14n.erl
@@ -65,21 +65,14 @@ exc_child(Text, _InputNs, _OutputNs) when is_binary(Text) -> escape_text(binary_
 %% (or has a different value), emit the declaration.
 exc_needed_decls(VisiblyUsedSet, InputNs, OutputParentNs) ->
     VisiblyUsed = sets:to_list(VisiblyUsedSet),
-    lists:filtermap(
-        fun(Prefix) ->
-            case maps:find(Prefix, InputNs) of
-                {ok, Uri} ->
-                    NeedEmit = maps:get(Prefix, OutputParentNs, undefined) =/= Uri,
-                    case NeedEmit of
-                        true -> {true, {prefix_to_ns_decl(Prefix), Uri}};
-                        false -> false
-                    end;
-                error ->
-                    false
-            end
-        end,
-        VisiblyUsed
-    ).
+    lists:filtermap(fun(Prefix) -> exc_need_emit(Prefix, InputNs, OutputParentNs) end, VisiblyUsed).
+
+exc_need_emit(Prefix, InputNs, OutputParentNs) ->
+    case {maps:find(Prefix, InputNs), maps:find(Prefix, OutputParentNs)} of
+        {{ok, Uri}, {ok, Uri}} -> false;
+        {{ok, Uri}, _} -> {true, {prefix_to_ns_decl(Prefix), Uri}};
+        {error, _} -> false
+    end.
 
 prefix_to_ns_decl("") -> "xmlns";
 prefix_to_ns_decl(Prefix) -> "xmlns:" ++ Prefix.

--- a/src/signerl_c14n.erl
+++ b/src/signerl_c14n.erl
@@ -156,17 +156,8 @@ attr_sort_key(Name, NsMap) ->
 %% --- Rendering ---
 
 render_element(TagStr, NsDecls, Attrs, ChildrenIo) ->
-    [
-        "<",
-        TagStr,
-        render_ns_decls(NsDecls),
-        render_attributes(Attrs),
-        ">",
-        ChildrenIo,
-        "</",
-        TagStr,
-        ">"
-    ].
+    ["<", TagStr, render_ns_decls(NsDecls), render_attributes(Attrs), ">",
+     ChildrenIo, "</", TagStr, ">"].
 
 render_ns_decls([]) ->
     [];

--- a/src/signerl_c14n.erl
+++ b/src/signerl_c14n.erl
@@ -1,43 +1,106 @@
 -module(signerl_c14n).
 
--export([canonicalize/1, remove_signature_elements/1]).
+-export([canonicalize/1, canonicalize/2, remove_signature_elements/1]).
+
+-type c14n_mode() :: c14n11 | exc_c14n.
+-export_type([c14n_mode/0]).
 
 -spec canonicalize(signerl_xml:simplified_xml()) -> binary().
 canonicalize(XmlTerm) ->
-    list_to_binary(canonicalize_element(XmlTerm, #{})).
+    canonicalize(XmlTerm, c14n11).
+
+-spec canonicalize(signerl_xml:simplified_xml(), c14n_mode()) -> binary().
+canonicalize(XmlTerm, c14n11) ->
+    list_to_binary(c14n11_element(XmlTerm, #{}));
+canonicalize(XmlTerm, exc_c14n) ->
+    list_to_binary(exc_element(XmlTerm, #{}, #{})).
 
 -spec remove_signature_elements(signerl_xml:simplified_xml()) -> signerl_xml:simplified_xml().
 remove_signature_elements({Tag, Attrs, Children}) ->
-    Filtered = [C || C <- Children, not is_signature_element(C)],
+    Filtered = [C || C <- Children, not signerl_xml:is_signature_element(C)],
     {Tag, Attrs, Filtered}.
 
-is_signature_element({'ds:Signature', _, _}) -> true;
-is_signature_element(_) -> false.
+%% ====================================================================
+%% C14N 1.1 — emit all new/changed ns decls, inherit everything
+%% ====================================================================
 
-%% --- Element serialization ---
-
--spec canonicalize_element(signerl_xml:simplified_xml(), map()) -> iolist().
-canonicalize_element({Tag, Attrs, Children}, ParentNs) ->
+c14n11_element({Tag, Attrs, Children}, ParentNs) ->
     TagStr = atom_to_list(Tag),
     {NsDecls, RegularAttrs} = partition_attrs(Attrs),
     CurrentNs = merge_namespaces(ParentNs, NsDecls),
     NewNsDecls = new_namespace_decls(ParentNs, NsDecls),
-    VisiblyUsed = visibly_used_prefixes(TagStr, RegularAttrs),
-    EmittedNsDecls = filter_visibly_used(NewNsDecls, VisiblyUsed, ParentNs),
-    SortedNsDecls = sort_ns_decls(EmittedNsDecls),
+    SortedNsDecls = sort_ns_decls(NewNsDecls),
     SortedAttrs = sort_attributes(RegularAttrs, CurrentNs),
-    Result = [
+    [
         "<",
         TagStr,
         render_ns_decls(SortedNsDecls),
         render_attributes(SortedAttrs),
         ">",
-        render_children(Children, CurrentNs),
+        [c14n11_child(C, CurrentNs) || C <- Children],
         "</",
         TagStr,
         ">"
-    ],
-    Result.
+    ].
+
+c14n11_child({_, _, _} = Element, Ns) -> c14n11_element(Element, Ns);
+c14n11_child(Text, _Ns) when is_list(Text) -> escape_text(Text);
+c14n11_child(Text, _Ns) when is_binary(Text) -> escape_text(binary_to_list(Text)).
+
+%% ====================================================================
+%% Exclusive C14N — only emit visibly utilized ns decls
+%% InputNs: all namespaces in scope from the input document
+%% OutputNs: namespaces emitted by output ancestors
+%% ====================================================================
+
+exc_element({Tag, Attrs, Children}, InputParentNs, OutputParentNs) ->
+    TagStr = atom_to_list(Tag),
+    {NsDecls, RegularAttrs} = partition_attrs(Attrs),
+    InputNs = merge_namespaces(InputParentNs, NsDecls),
+    VisiblyUsed = visibly_used_prefixes(TagStr, RegularAttrs),
+    %% Emit ns decls for visibly used prefixes not already in output scope
+    EmittedNsDecls = exc_needed_decls(VisiblyUsed, InputNs, OutputParentNs),
+    OutputNs = merge_namespaces(OutputParentNs, EmittedNsDecls),
+    SortedNsDecls = sort_ns_decls(EmittedNsDecls),
+    SortedAttrs = sort_attributes(RegularAttrs, InputNs),
+    [
+        "<",
+        TagStr,
+        render_ns_decls(SortedNsDecls),
+        render_attributes(SortedAttrs),
+        ">",
+        [exc_child(C, InputNs, OutputNs) || C <- Children],
+        "</",
+        TagStr,
+        ">"
+    ].
+
+exc_child({_, _, _} = Element, InputNs, OutputNs) -> exc_element(Element, InputNs, OutputNs);
+exc_child(Text, _InputNs, _OutputNs) when is_list(Text) -> escape_text(Text);
+exc_child(Text, _InputNs, _OutputNs) when is_binary(Text) -> escape_text(binary_to_list(Text)).
+
+%% For each visibly used prefix, if it's in InputNs but not in OutputParentNs
+%% (or has a different value), emit the declaration.
+exc_needed_decls(VisiblyUsedSet, InputNs, OutputParentNs) ->
+    VisiblyUsed = sets:to_list(VisiblyUsedSet),
+    lists:filtermap(
+        fun(Prefix) ->
+            case maps:find(Prefix, InputNs) of
+                {ok, Uri} ->
+                    NeedEmit = maps:get(Prefix, OutputParentNs, undefined) =/= Uri,
+                    case NeedEmit of
+                        true -> {true, {prefix_to_ns_decl(Prefix), Uri}};
+                        false -> false
+                    end;
+                error ->
+                    false
+            end
+        end,
+        VisiblyUsed
+    ).
+
+prefix_to_ns_decl("") -> "xmlns";
+prefix_to_ns_decl(Prefix) -> "xmlns:" ++ Prefix.
 
 %% --- Attribute partitioning ---
 
@@ -81,13 +144,6 @@ new_namespace_decls(ParentNs, NsDecls) ->
 ns_decl_prefix("xmlns") -> "";
 ns_decl_prefix("xmlns:" ++ Prefix) -> Prefix.
 
-%% --- Visible use filtering ---
-%% C14N 1.1 §2.3: only emit namespace declarations for prefixes
-%% that are visibly utilized by the element or its attributes.
-%% For full-document canonicalization (not document subsets),
-%% we emit all new/changed declarations since they are needed
-%% by the element itself or its descendants.
-
 visibly_used_prefixes(TagStr, RegularAttrs) ->
     TagPrefix = extract_prefix(TagStr),
     AttrPrefixes = [extract_prefix(N) || {N, _} <- RegularAttrs, extract_prefix(N) =/= ""],
@@ -98,12 +154,6 @@ extract_prefix(Name) ->
         [Prefix, _] -> Prefix;
         [_] -> ""
     end.
-
-filter_visibly_used(NewNsDecls, _VisiblyUsed, _ParentNs) ->
-    %% For full-document canonicalization, all new/changed namespace
-    %% declarations must be emitted (they may be needed by descendants).
-    %% Superfluous declarations are already filtered by new_namespace_decls/2.
-    NewNsDecls.
 
 %% --- Sorting ---
 
@@ -147,18 +197,6 @@ render_attributes([]) ->
 render_attributes([{Name, Value} | Rest]) ->
     StrValue = value_to_string(Value),
     [" ", Name, "=\"", escape_attr_value(StrValue), "\"" | render_attributes(Rest)].
-
-render_children([], _Ns) ->
-    [];
-render_children([Child | Rest], Ns) ->
-    [render_child(Child, Ns) | render_children(Rest, Ns)].
-
-render_child({_, _, _} = Element, Ns) ->
-    canonicalize_element(Element, Ns);
-render_child(Text, _Ns) when is_list(Text) ->
-    escape_text(Text);
-render_child(Text, _Ns) when is_binary(Text) ->
-    escape_text(binary_to_list(Text)).
 
 %% --- Escaping (C14N 1.1 §2.3) ---
 

--- a/src/signerl_c14n.erl
+++ b/src/signerl_c14n.erl
@@ -31,17 +31,8 @@ c14n11_element({Tag, Attrs, Children}, ParentNs) ->
     NewNsDecls = new_namespace_decls(ParentNs, NsDecls),
     SortedNsDecls = sort_ns_decls(NewNsDecls),
     SortedAttrs = sort_attributes(RegularAttrs, CurrentNs),
-    [
-        "<",
-        TagStr,
-        render_ns_decls(SortedNsDecls),
-        render_attributes(SortedAttrs),
-        ">",
-        [c14n11_child(C, CurrentNs) || C <- Children],
-        "</",
-        TagStr,
-        ">"
-    ].
+    ChildrenIo = [c14n11_child(C, CurrentNs) || C <- Children],
+    render_element(TagStr, SortedNsDecls, SortedAttrs, ChildrenIo).
 
 c14n11_child({_, _, _} = Element, Ns) -> c14n11_element(Element, Ns);
 c14n11_child(Text, _Ns) when is_list(Text) -> escape_text(Text);
@@ -63,17 +54,8 @@ exc_element({Tag, Attrs, Children}, InputParentNs, OutputParentNs) ->
     OutputNs = merge_namespaces(OutputParentNs, EmittedNsDecls),
     SortedNsDecls = sort_ns_decls(EmittedNsDecls),
     SortedAttrs = sort_attributes(RegularAttrs, InputNs),
-    [
-        "<",
-        TagStr,
-        render_ns_decls(SortedNsDecls),
-        render_attributes(SortedAttrs),
-        ">",
-        [exc_child(C, InputNs, OutputNs) || C <- Children],
-        "</",
-        TagStr,
-        ">"
-    ].
+    ChildrenIo = [exc_child(C, InputNs, OutputNs) || C <- Children],
+    render_element(TagStr, SortedNsDecls, SortedAttrs, ChildrenIo).
 
 exc_child({_, _, _} = Element, InputNs, OutputNs) -> exc_element(Element, InputNs, OutputNs);
 exc_child(Text, _InputNs, _OutputNs) when is_list(Text) -> escape_text(Text);
@@ -135,11 +117,7 @@ merge_namespaces(ParentNs, NsDecls) ->
     ).
 
 new_namespace_decls(ParentNs, NsDecls) ->
-    [
-        {NameStr, Value}
-     || {NameStr, Value} <- NsDecls,
-        maps:get(ns_decl_prefix(NameStr), ParentNs, undefined) =/= Value
-    ].
+    [{N, V} || {N, V} <- NsDecls, maps:get(ns_decl_prefix(N), ParentNs, undefined) =/= V].
 
 ns_decl_prefix("xmlns") -> "";
 ns_decl_prefix("xmlns:" ++ Prefix) -> Prefix.
@@ -166,10 +144,7 @@ sort_ns_decls(NsDecls) ->
     ).
 
 sort_attributes(Attrs, NsMap) ->
-    Keyed = [
-        {attr_sort_key(Name, NsMap), Name, Value}
-     || {Name, Value} <- Attrs
-    ],
+    Keyed = [{attr_sort_key(Name, NsMap), Name, Value} || {Name, Value} <- Attrs],
     Sorted = lists:sort(
         fun({KeyA, _, _}, {KeyB, _, _}) -> KeyA =< KeyB end,
         Keyed
@@ -186,6 +161,19 @@ attr_sort_key(Name, NsMap) ->
     end.
 
 %% --- Rendering ---
+
+render_element(TagStr, NsDecls, Attrs, ChildrenIo) ->
+    [
+        "<",
+        TagStr,
+        render_ns_decls(NsDecls),
+        render_attributes(Attrs),
+        ">",
+        ChildrenIo,
+        "</",
+        TagStr,
+        ">"
+    ].
 
 render_ns_decls([]) ->
     [];

--- a/src/signerl_dsig_utils.erl
+++ b/src/signerl_dsig_utils.erl
@@ -3,8 +3,8 @@
 
 -export([digest_base64/2, signature_method_uri_for_key/1]).
 
-digest_base64(Hash, Payload) ->
-    base64:encode(crypto:hash(Hash, Payload)).
+digest_base64(HashAlgorithm, Payload) ->
+    base64:encode(crypto:hash(HashAlgorithm, Payload)).
 
 signature_method_uri_for_key(Key) when is_tuple(Key), tuple_size(Key) > 0 ->
     case element(1, Key) of

--- a/src/signerl_signature.erl
+++ b/src/signerl_signature.erl
@@ -40,11 +40,7 @@ construct_signature_without_value(Message, Hash, DigestMethodUri, SignatureMetho
     SignedInfo = signed_info(Message, SignedProperties, Hash, DigestMethodUri, SignatureMethodUri),
     KeyInfoElement = key_info(CertDer),
     SignatureElement =
-        {'ds:Signature',
-            [
-                {'xmlns:ds', ?DSIG_NAMESPACE_URI},
-                {'Id', ?SIGNATURE_ID}
-            ],
+        {'ds:Signature', [{'xmlns:ds', ?DSIG_NAMESPACE_URI}, {'Id', ?SIGNATURE_ID}],
             [SignedInfo] ++ KeyInfoElement ++ [signature_object(SignedProperties)]},
     {ok, SignatureElement, SignedInfo}.
 
@@ -52,13 +48,7 @@ key_info(undefined) ->
     [];
 key_info(CertDer) when is_binary(CertDer) ->
     CertB64 = binary_to_list(base64:encode(CertDer)),
-    [
-        {'ds:KeyInfo', [], [
-            {'ds:X509Data', [], [
-                {'ds:X509Certificate', [], [CertB64]}
-            ]}
-        ]}
-    ].
+    [{'ds:KeyInfo', [], [{'ds:X509Data', [], [{'ds:X509Certificate', [], [CertB64]}]}]}].
 
 signed_info(Message, SignedProperties, Hash, DigestMethodUri, SignatureMethodUri) ->
     MessageDigest = signerl_dsig_utils:digest_base64(Hash, signerl_c14n:canonicalize(Message)),
@@ -86,10 +76,7 @@ signed_info(Message, SignedProperties, Hash, DigestMethodUri, SignatureMethodUri
                 {'URI', "#" ++ ?SIGNED_PROPERTIES_ID},
                 {'Type', ?XADES_SIGNED_PROPERTIES_TYPE_URI}
             ],
-            [
-                DigestMethodElement,
-                SignedPropertiesDigestElement
-            ]
+            [DigestMethodElement, SignedPropertiesDigestElement]
         )
     ]}.
 
@@ -111,9 +98,7 @@ signature_object(SignedProperties) ->
                 {'xmlns:xades', ?XADES_NAMESPACE_URI},
                 {'Target', "#" ++ ?SIGNATURE_ID}
             ],
-            [
-                SignedProperties
-            ]}
+            [SignedProperties]}
     ]}.
 
 signed_properties(SigningTime) ->

--- a/src/signerl_signature.erl
+++ b/src/signerl_signature.erl
@@ -3,11 +3,11 @@
 
 -export([build_signature_element/4]).
 
--spec build_signature_element(Message, Hash, Key, CertDer) ->
+-spec build_signature_element(Message, HashAlgorithm, Key, CertDer) ->
     {ok, signerl_xml:simplified_xml()} | {error, unsupported_hash | unsupported_key}
 when
     Message :: signerl_xml:simplified_xml(),
-    Hash :: atom(),
+    HashAlgorithm :: atom(),
     Key :: public_key:private_key(),
     CertDer :: binary() | undefined.
 build_signature_element(Message, sha256, Key, CertDer) ->
@@ -22,22 +22,26 @@ build_signature_element(Message, sha256, Key, CertDer) ->
 build_signature_element(_Message, _Hash, _Key, _CertDer) ->
     {error, unsupported_hash}.
 
-build_signature_element_with_method_uri(Message, Hash, Key, SignatureMethodUri, CertDer) ->
+build_signature_element_with_method_uri(Message, HashAlgorithm, Key, SignatureMethodUri, CertDer) ->
     {ok, SignatureElementWithoutValue, SignedInfo} =
         construct_signature_without_value(
-            Message, Hash, ?DSIG_DIGEST_SHA256_URI, SignatureMethodUri, CertDer
+            Message, HashAlgorithm, ?DSIG_DIGEST_SHA256_URI, SignatureMethodUri, CertDer
         ),
     SignedInfoBytes = signerl_c14n:canonicalize(SignedInfo),
-    SignatureBytes = public_key:sign(SignedInfoBytes, Hash, Key),
+    SignatureBytes = public_key:sign(SignedInfoBytes, HashAlgorithm, Key),
     SignatureValue = base64:encode(SignatureBytes),
     SignatureElement =
         add_signature_value(SignatureElementWithoutValue, binary_to_list(SignatureValue)),
     {ok, SignatureElement}.
 
-construct_signature_without_value(Message, Hash, DigestMethodUri, SignatureMethodUri, CertDer) ->
+construct_signature_without_value(
+    Message, HashAlgorithm, DigestMethodUri, SignatureMethodUri, CertDer
+) ->
     SigningTime = signerl_utils:current_utc_timestamp(),
     SignedProperties = signed_properties(SigningTime),
-    SignedInfo = signed_info(Message, SignedProperties, Hash, DigestMethodUri, SignatureMethodUri),
+    SignedInfo = signed_info(
+        Message, SignedProperties, HashAlgorithm, DigestMethodUri, SignatureMethodUri
+    ),
     KeyInfoElement = key_info(CertDer),
     SignatureElement =
         {'ds:Signature', [{'xmlns:ds', ?DSIG_NAMESPACE_URI}, {'Id', ?SIGNATURE_ID}],
@@ -50,10 +54,14 @@ key_info(CertDer) when is_binary(CertDer) ->
     CertB64 = binary_to_list(base64:encode(CertDer)),
     [{'ds:KeyInfo', [], [{'ds:X509Data', [], [{'ds:X509Certificate', [], [CertB64]}]}]}].
 
-signed_info(Message, SignedProperties, Hash, DigestMethodUri, SignatureMethodUri) ->
-    MessageDigest = signerl_dsig_utils:digest_base64(Hash, signerl_c14n:canonicalize(Message)),
+signed_info(Message, SignedProperties, HashAlgorithm, DigestMethodUri, SignatureMethodUri) ->
+    MessageDigest = signerl_dsig_utils:digest_base64(
+        HashAlgorithm, signerl_c14n:canonicalize(Message)
+    ),
     SignedPropertiesDigest =
-        signerl_dsig_utils:digest_base64(Hash, signerl_c14n:canonicalize(SignedProperties)),
+        signerl_dsig_utils:digest_base64(
+            HashAlgorithm, signerl_c14n:canonicalize(SignedProperties)
+        ),
     DigestMethodElement = {'ds:DigestMethod', [{'Algorithm', DigestMethodUri}], []},
     MessageDigestElement = {'ds:DigestValue', [], [binary_to_list(MessageDigest)]},
     SignedPropertiesDigestElement =

--- a/src/signerl_signature.erl
+++ b/src/signerl_signature.erl
@@ -1,28 +1,31 @@
 -module(signerl_signature).
 -include("signerl_dsig.hrl").
 
--export([build_signature_element/3]).
+-export([build_signature_element/4]).
 
--spec build_signature_element(Message, Hash, Key) ->
+-spec build_signature_element(Message, Hash, Key, CertDer) ->
     {ok, signerl_xml:simplified_xml()} | {error, unsupported_hash | unsupported_key}
 when
     Message :: signerl_xml:simplified_xml(),
     Hash :: atom(),
-    Key :: public_key:private_key().
-build_signature_element(Message, sha256, Key) ->
+    Key :: public_key:private_key(),
+    CertDer :: binary() | undefined.
+build_signature_element(Message, sha256, Key, CertDer) ->
     case signerl_dsig_utils:signature_method_uri_for_key(Key) of
         {ok, SignatureMethodUri} ->
-            build_signature_element_with_method_uri(Message, sha256, Key, SignatureMethodUri);
+            build_signature_element_with_method_uri(
+                Message, sha256, Key, SignatureMethodUri, CertDer
+            );
         error ->
             {error, unsupported_key}
     end;
-build_signature_element(_Message, _Hash, _Key) ->
+build_signature_element(_Message, _Hash, _Key, _CertDer) ->
     {error, unsupported_hash}.
 
-build_signature_element_with_method_uri(Message, Hash, Key, SignatureMethodUri) ->
+build_signature_element_with_method_uri(Message, Hash, Key, SignatureMethodUri, CertDer) ->
     {ok, SignatureElementWithoutValue, SignedInfo} =
         construct_signature_without_value(
-            Message, Hash, ?DSIG_DIGEST_SHA256_URI, SignatureMethodUri
+            Message, Hash, ?DSIG_DIGEST_SHA256_URI, SignatureMethodUri, CertDer
         ),
     SignedInfoBytes = signerl_c14n:canonicalize(SignedInfo),
     SignatureBytes = public_key:sign(SignedInfoBytes, Hash, Key),
@@ -31,21 +34,31 @@ build_signature_element_with_method_uri(Message, Hash, Key, SignatureMethodUri) 
         add_signature_value(SignatureElementWithoutValue, binary_to_list(SignatureValue)),
     {ok, SignatureElement}.
 
-construct_signature_without_value(Message, Hash, DigestMethodUri, SignatureMethodUri) ->
+construct_signature_without_value(Message, Hash, DigestMethodUri, SignatureMethodUri, CertDer) ->
     SigningTime = signerl_utils:current_utc_timestamp(),
     SignedProperties = signed_properties(SigningTime),
     SignedInfo = signed_info(Message, SignedProperties, Hash, DigestMethodUri, SignatureMethodUri),
+    KeyInfoElement = key_info(CertDer),
     SignatureElement =
         {'ds:Signature',
             [
                 {'xmlns:ds', ?DSIG_NAMESPACE_URI},
                 {'Id', ?SIGNATURE_ID}
             ],
-            [
-                SignedInfo,
-                signature_object(SignedProperties)
-            ]},
+            [SignedInfo] ++ KeyInfoElement ++ [signature_object(SignedProperties)]},
     {ok, SignatureElement, SignedInfo}.
+
+key_info(undefined) ->
+    [];
+key_info(CertDer) when is_binary(CertDer) ->
+    CertB64 = binary_to_list(base64:encode(CertDer)),
+    [
+        {'ds:KeyInfo', [], [
+            {'ds:X509Data', [], [
+                {'ds:X509Certificate', [], [CertB64]}
+            ]}
+        ]}
+    ].
 
 signed_info(Message, SignedProperties, Hash, DigestMethodUri, SignatureMethodUri) ->
     MessageDigest = signerl_dsig_utils:digest_base64(Hash, signerl_c14n:canonicalize(Message)),
@@ -83,11 +96,12 @@ signed_info(Message, SignedProperties, Hash, DigestMethodUri, SignatureMethodUri
 reference(Attrs, Content) ->
     {'ds:Reference', Attrs, Content}.
 
-add_signature_value({'ds:Signature', Attrs, [SignedInfo, Object]}, SignatureValue) ->
+add_signature_value({'ds:Signature', Attrs, Content}, SignatureValue) ->
+    [SignedInfo | Rest] = Content,
     {'ds:Signature', Attrs, [
         SignedInfo,
-        {'ds:SignatureValue', [], [SignatureValue]},
-        Object
+        {'ds:SignatureValue', [], [SignatureValue]}
+        | Rest
     ]}.
 
 signature_object(SignedProperties) ->

--- a/src/signerl_verify.erl
+++ b/src/signerl_verify.erl
@@ -2,13 +2,15 @@
 -feature(maybe_expr, enable).
 -include("signerl_dsig.hrl").
 
--export([extract_signature_data/1, verify_reference_digests/2]).
+-export([extract_signature_data/1, verify_reference_digests/2, c14n_mode/1]).
 
 -spec extract_signature_data(Message) -> Result when
     Message :: signerl_xml:simplified_xml(),
     Result :: {ok, map()} | {error, atom()}.
 extract_signature_data({Tag, Attrs, Content}) ->
-    {SignatureElements, UnsignedContent} = lists:partition(fun is_signature_element/1, Content),
+    {SignatureElements, UnsignedContent} = lists:partition(
+        fun signerl_xml:is_signature_element/1, Content
+    ),
     case SignatureElements of
         [SignatureElement] ->
             decode_signature_data(SignatureElement, {Tag, Attrs, UnsignedContent});
@@ -71,20 +73,17 @@ decode_signature_data(SignatureElement, UnsignedMessage) ->
         {ok, SignedProperties} ?= signerl_signed_properties:extract(SignatureElement),
         {ok, SignedInfoElement} ?= signed_info_element(SignatureElement),
         {ok, References} ?= signed_info_references(SignedInfoElement),
+        KeyInfo = extract_key_info(SignatureElement),
         {ok, #{
             signature_bytes => SignatureBytes,
             unsigned_message => UnsignedMessage,
             signed_properties => SignedProperties,
             signature_element => SignatureElement,
             signed_info_element => SignedInfoElement,
-            references => References
+            references => References,
+            key_info => KeyInfo
         }}
     end.
-
-is_signature_element({'ds:Signature', _, _}) ->
-    true;
-is_signature_element(_) ->
-    false.
 
 signature_value({'ds:Signature', _, _} = SignatureElement) ->
     decode_signature_value(signerl_xml:find_path(['ds:SignatureValue'], SignatureElement)).
@@ -198,7 +197,8 @@ decode_transform_uris([_Other | _Rest], _Acc) ->
 
 validate_signed_info_algorithms(References, SignatureMethodUris) ->
     maybe
-        {ok, ?DSIG_C14N11_ALGO_URI} ?= maps:find(c14n_algorithm, References),
+        {ok, C14NAlgorithm} ?= maps:find(c14n_algorithm, References),
+        true ?= is_supported_c14n(C14NAlgorithm),
         {ok, SignatureMethodUri} ?= maps:find(signature_algorithm, References),
         true ?= lists:member(SignatureMethodUri, SignatureMethodUris),
         ok
@@ -206,6 +206,10 @@ validate_signed_info_algorithms(References, SignatureMethodUris) ->
         _ ->
             {error, unsupported_algorithm}
     end.
+
+is_supported_c14n(?DSIG_C14N11_ALGO_URI) -> true;
+is_supported_c14n(?DSIG_EXC_C14N_ALGO_URI) -> true;
+is_supported_c14n(_) -> false.
 
 validate_document_reference(Reference, DigestMethodUri) ->
     maybe
@@ -256,3 +260,28 @@ digest_method_uri(sha256) ->
     {ok, ?DSIG_DIGEST_SHA256_URI};
 digest_method_uri(_) ->
     {error, unsupported_hash}.
+
+-spec c14n_mode(map()) -> signerl_c14n:c14n_mode().
+c14n_mode(#{references := #{c14n_algorithm := ?DSIG_EXC_C14N_ALGO_URI}}) ->
+    exc_c14n;
+c14n_mode(_) ->
+    c14n11.
+
+extract_key_info(SignatureElement) ->
+    case signerl_xml:find_path(['ds:KeyInfo'], SignatureElement) of
+        {ok, KeyInfoElement} ->
+            extract_x509_certificate(KeyInfoElement);
+        {error, not_found} ->
+            undefined
+    end.
+
+extract_x509_certificate(KeyInfoElement) ->
+    case signerl_xml:find_path(['ds:X509Data', 'ds:X509Certificate'], KeyInfoElement) of
+        {ok, {_, _, [CertB64]}} when is_list(CertB64) ->
+            case decode_base64_binary(list_to_binary(CertB64)) of
+                {ok, CertDer} -> #{x509_certificate => CertDer};
+                {error, _} -> undefined
+            end;
+        _ ->
+            undefined
+    end.

--- a/src/signerl_verify.erl
+++ b/src/signerl_verify.erl
@@ -18,9 +18,9 @@ extract_signature_data({Tag, Attrs, Content}) ->
             {error, missing_signature}
     end.
 
--spec verify_reference_digests(SignatureData, Hash) -> Result when
+-spec verify_reference_digests(SignatureData, HashAlgorithm) -> Result when
     SignatureData :: map(),
-    Hash :: atom(),
+    HashAlgorithm :: atom(),
     Result :: true | false | {error, atom()}.
 verify_reference_digests(
     #{
@@ -33,10 +33,10 @@ verify_reference_digests(
             } = SignedPropertiesReference
         } = References
     },
-    Hash
+    HashAlgorithm
 ) ->
     maybe
-        {ok, DigestMethodUri} ?= digest_method_uri(Hash),
+        {ok, DigestMethodUri} ?= digest_method_uri(HashAlgorithm),
         SignatureMethodUris = [?DSIG_SIG_RSA_SHA256_URI, ?DSIG_SIG_ECDSA_SHA256_URI],
         ok ?= validate_signed_info_algorithms(References, SignatureMethodUris),
         ok ?= validate_document_reference(DocumentReference, DigestMethodUri),
@@ -47,8 +47,8 @@ verify_reference_digests(
             signerl_c14n:remove_signature_elements(UnsignedMessage)
         ),
         SignedPropertiesPayload = signerl_c14n:canonicalize(SignedPropertiesElement),
-        DocumentDigest = crypto:hash(Hash, DocumentPayload),
-        SignedPropertiesDigest = crypto:hash(Hash, SignedPropertiesPayload),
+        DocumentDigest = crypto:hash(HashAlgorithm, DocumentPayload),
+        SignedPropertiesDigest = crypto:hash(HashAlgorithm, SignedPropertiesPayload),
         case
             {
                 DocumentDigest =:= DocumentDigestValue,
@@ -276,12 +276,12 @@ extract_key_info(SignatureElement) ->
     end.
 
 extract_x509_certificate(KeyInfoElement) ->
-    case signerl_xml:find_path(['ds:X509Data', 'ds:X509Certificate'], KeyInfoElement) of
-        {ok, {_, _, [CertB64]}} when is_list(CertB64) ->
-            case decode_base64_binary(list_to_binary(CertB64)) of
-                {ok, CertDer} -> #{x509_certificate => CertDer};
-                {error, _} -> undefined
-            end;
-        _ ->
-            undefined
+    maybe
+        {ok, {_, _, [CertB64]}} ?=
+            signerl_xml:find_path(['ds:X509Data', 'ds:X509Certificate'], KeyInfoElement),
+        true ?= is_list(CertB64),
+        {ok, CertDer} ?= decode_base64_binary(list_to_binary(CertB64)),
+        #{x509_certificate => CertDer}
+    else
+        _ -> undefined
     end.

--- a/src/signerl_xml.erl
+++ b/src/signerl_xml.erl
@@ -10,6 +10,7 @@
     single_text/1,
     attr_value/2,
     attr_value_or_undefined/2,
+    is_signature_element/1,
     export_fragment/1,
     export/2,
     to_file/2
@@ -146,6 +147,10 @@ attr_value_or_undefined(Key, Attrs) ->
         false ->
             undefined
     end.
+
+-spec is_signature_element(term()) -> boolean().
+is_signature_element({'ds:Signature', _, _}) -> true;
+is_signature_element(_) -> false.
 
 find_unique_child(Tag, {_, _, Content}) ->
     Children = [Element || Element = {TagValue, _, _} <- Content, TagValue =:= Tag],

--- a/test/signerl_SUITE.erl
+++ b/test/signerl_SUITE.erl
@@ -106,6 +106,13 @@ groups() ->
         {interop_smoke_group, [], [
             c14n_idempotent_after_sign,
             is_signature_element_shared
+        ]},
+        {xml_utils_group, [], [
+            export_fragment_returns_binary,
+            to_file_writes_and_reads_back,
+            parse_prolog_rejects_bom,
+            single_text_returns_binary_and_list,
+            single_text_returns_not_found
         ]}
     ].
 
@@ -118,6 +125,7 @@ all() ->
         {group, verify_tamper_group},
         {group, keyinfo_group},
         {group, interop_smoke_group},
+        {group, xml_utils_group},
         extract_signature_returns_error_without_signature_element_direct,
         xades_xml_returns_error_with_non_signature_input,
         c14n_mode_returns_exc_for_exc_c14n_algorithm,
@@ -1163,3 +1171,33 @@ corrupt_x509_certificate_child({'ds:X509Certificate', Attrs, _}, Replacement) ->
     {'ds:X509Certificate', Attrs, Replacement};
 corrupt_x509_certificate_child(Other, _Replacement) ->
     Other.
+
+%% xml_utils_group tests
+
+export_fragment_returns_binary(_Config) ->
+    Element = {tag, [], ["content"]},
+    Result = signerl_xml:export_fragment(Element),
+    ?assert(is_binary(Result)),
+    ?assertNotEqual(<<>>, Result).
+
+to_file_writes_and_reads_back(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    OutPath = filename:join(PrivDir, "to_file_test.xml"),
+    Prolog = ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>"],
+    Root = signerl_xml:parse_file("test/examples/base/books.xml"),
+    Binary = signerl_xml:export(Prolog, Root),
+    ok = signerl_xml:to_file(OutPath, Binary),
+    ReadBack = signerl_xml:parse_file(OutPath),
+    ?assertEqual(Root, ReadBack).
+
+parse_prolog_rejects_bom(_Config) ->
+    Message = <<16#EF, 16#BB, 16#BF, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root/>">>,
+    ?assertEqual({error, invalid_prolog}, signerl_xml:parse_prolog(Message)).
+
+single_text_returns_binary_and_list(_Config) ->
+    ?assertEqual({ok, <<"abc">>}, signerl_xml:single_text({tag, [], [<<"abc">>]})),
+    ?assertEqual({ok, <<"abc">>}, signerl_xml:single_text({tag, [], ["abc"]})).
+
+single_text_returns_not_found(_Config) ->
+    ?assertEqual({error, not_found}, signerl_xml:single_text({tag, [], []})),
+    ?assertEqual({error, not_found}, signerl_xml:single_text({tag, [], ["a", "b"]})).

--- a/test/signerl_SUITE.erl
+++ b/test/signerl_SUITE.erl
@@ -42,7 +42,9 @@ groups() ->
             sign_returns_error_with_unsupported_key,
             sign_returns_file_error_with_missing_message_file,
             sign_returns_file_error_with_missing_key_file,
-            sign_returns_error_with_invalid_pem_key_file
+            sign_returns_error_with_invalid_pem_key_file,
+            sign4_returns_file_error_with_missing_message_file,
+            sign4_returns_file_error_with_missing_key_file
         ]},
         {verify_fixture_error_group, [], [
             verify_missing_prolog_binary_returns_error,
@@ -71,6 +73,7 @@ groups() ->
             verify_returns_error_without_signed_info,
             extract_signature_data_returns_error_with_missing_c14n,
             verify_reference_digests_returns_error_with_invalid_c14n_algorithm,
+            verify_reference_digests_accepts_exc_c14n_algorithm,
             verify_reference_digests_returns_error_with_invalid_signature_method_algorithm,
             extract_signature_data_returns_error_with_missing_reference_uri,
             extract_signature_data_returns_error_with_invalid_reference_payload,
@@ -89,6 +92,20 @@ groups() ->
             verify_fails_on_modified_message,
             verify_fails_on_modified_signing_time,
             verify_fails_with_wrong_keys
+        ]},
+        {keyinfo_group, [], [
+            sign_with_certificate_includes_keyinfo,
+            sign_without_certificate_omits_keyinfo,
+            sign_with_certificate_roundtrip_rsa,
+            sign_with_certificate_roundtrip_ecdsa,
+            sign_with_certificate_from_key_file,
+            sign_with_certificate_from_message_file,
+            verify_extracts_certificate_from_keyinfo,
+            verify_extracts_no_keyinfo_when_absent
+        ]},
+        {interop_smoke_group, [], [
+            c14n_idempotent_after_sign,
+            is_signature_element_shared
         ]}
     ].
 
@@ -99,8 +116,12 @@ all() ->
         {group, verify_fixture_error_group},
         {group, verify_signed_info_error_group},
         {group, verify_tamper_group},
+        {group, keyinfo_group},
+        {group, interop_smoke_group},
         extract_signature_returns_error_without_signature_element_direct,
-        xades_xml_returns_error_with_non_signature_input
+        xades_xml_returns_error_with_non_signature_input,
+        c14n_mode_returns_exc_for_exc_c14n_algorithm,
+        extract_x509_certificate_returns_undefined_for_invalid_cert
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%
@@ -166,6 +187,45 @@ init_per_group(verify_tamper_group, Config) ->
         {wrong_public_key, WrongPublicKey}
         | Config
     ];
+init_per_group(keyinfo_group, Config) ->
+    MessagePath = signerl_utils:file_path("test/examples/base/books.xml"),
+    {ok, RawMessage} = file:read_file(MessagePath),
+    RsaKey = signerl_cert_helpers:signer_rsa_key(),
+    EcdsaKey = signerl_cert_helpers:signer_ecdsa_key(),
+    RsaCertDer = test_helpers:cert_der(signerl_cert_helpers:signer_rsa_cert_path()),
+    EcdsaCertDer = test_helpers:cert_der(signerl_cert_helpers:signer_ecdsa_cert_path()),
+    RsaPublicKey = test_helpers:rsa_public_key_from_cert(
+        signerl_cert_helpers:signer_rsa_cert_path()
+    ),
+    EcdsaPublicKey = test_helpers:ecdsa_public_key_from_cert(
+        signerl_cert_helpers:signer_ecdsa_cert_path()
+    ),
+    RsaKeyPath = signerl_cert_helpers:signer_rsa_key_path(),
+    [
+        {message_path, MessagePath},
+        {raw_message, RawMessage},
+        {rsa_key, RsaKey},
+        {rsa_key_path, RsaKeyPath},
+        {ecdsa_key, EcdsaKey},
+        {rsa_cert_der, RsaCertDer},
+        {ecdsa_cert_der, EcdsaCertDer},
+        {rsa_public_key, RsaPublicKey},
+        {ecdsa_public_key, EcdsaPublicKey}
+        | Config
+    ];
+init_per_group(interop_smoke_group, Config) ->
+    MessagePath = signerl_utils:file_path("test/examples/base/books.xml"),
+    {ok, RawMessage} = file:read_file(MessagePath),
+    RsaKey = signerl_cert_helpers:signer_rsa_key(),
+    RsaPublicKey = test_helpers:rsa_public_key_from_cert(
+        signerl_cert_helpers:signer_rsa_cert_path()
+    ),
+    [
+        {raw_message, RawMessage},
+        {rsa_key, RsaKey},
+        {rsa_public_key, RsaPublicKey}
+        | Config
+    ];
 init_per_group(_, Config) ->
     Config.
 
@@ -175,7 +235,9 @@ end_per_group(_, _Config) ->
 add_signature_element_inserts_signature_value(Config) ->
     Message = ?config(message, Config),
     Key = ?config(rsa_key, Config),
-    {ok, SignatureElement} = signerl_signature:build_signature_element(Message, sha256, Key),
+    {ok, SignatureElement} = signerl_signature:build_signature_element(
+        Message, sha256, Key, undefined
+    ),
     SignedMessage = signerl_xml:add_new_element(SignatureElement, Message),
     ?assertMatch(
         {ok, {'ds:SignatureValue', [], [_]}},
@@ -191,7 +253,9 @@ add_signature_element_inserts_signature_value(Config) ->
 add_signature_element_inserts_signed_properties(Config) ->
     Message = ?config(message, Config),
     Key = ?config(rsa_key, Config),
-    {ok, SignatureElement} = signerl_signature:build_signature_element(Message, sha256, Key),
+    {ok, SignatureElement} = signerl_signature:build_signature_element(
+        Message, sha256, Key, undefined
+    ),
     SignedMessage = signerl_xml:add_new_element(SignatureElement, Message),
     SignedMessageBin = signerl_xml:export(
         ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>"], SignedMessage
@@ -218,7 +282,9 @@ add_signature_element_inserts_signed_properties(Config) ->
 add_signature_element_extracts_signature_value(Config) ->
     Message = ?config(message, Config),
     Key = ?config(rsa_key, Config),
-    {ok, SignatureElement} = signerl_signature:build_signature_element(Message, sha256, Key),
+    {ok, SignatureElement} = signerl_signature:build_signature_element(
+        Message, sha256, Key, undefined
+    ),
     SignedMessage = signerl_xml:add_new_element(SignatureElement, Message),
     {ok, #{
         signature_bytes := SignatureBytes,
@@ -235,8 +301,12 @@ build_signature_element_rsa_and_ecdsa(Config) ->
     Message = ?config(message, Config),
     RsaKey = ?config(rsa_key, Config),
     EcdsaKey = ?config(ecdsa_key, Config),
-    {ok, RsaSignature} = signerl_signature:build_signature_element(Message, sha256, RsaKey),
-    {ok, EcdsaSignature} = signerl_signature:build_signature_element(Message, sha256, EcdsaKey),
+    {ok, RsaSignature} = signerl_signature:build_signature_element(
+        Message, sha256, RsaKey, undefined
+    ),
+    {ok, EcdsaSignature} = signerl_signature:build_signature_element(
+        Message, sha256, EcdsaKey, undefined
+    ),
 
     assert_has_signed_info(RsaSignature),
     assert_has_signed_info(EcdsaSignature).
@@ -246,15 +316,15 @@ build_signature_element_returns_error_with_invalid_hash_or_key(Config) ->
     RsaKey = ?config(rsa_key, Config),
     ?assertEqual(
         {error, unsupported_hash},
-        signerl_signature:build_signature_element(Message, sha512, RsaKey)
+        signerl_signature:build_signature_element(Message, sha512, RsaKey, undefined)
     ),
     ?assertEqual(
         {error, unsupported_key},
-        signerl_signature:build_signature_element(Message, sha256, invalid_key)
+        signerl_signature:build_signature_element(Message, sha256, invalid_key, undefined)
     ),
     ?assertEqual(
         {error, unsupported_key},
-        signerl_signature:build_signature_element(Message, sha256, {unsupported})
+        signerl_signature:build_signature_element(Message, sha256, {unsupported}, undefined)
     ).
 
 sign(_Config) ->
@@ -354,6 +424,20 @@ sign_returns_error_with_invalid_pem_key_file(Config) ->
     RawMessage = ?config(raw_message, Config),
     InvalidPemPath = signerl_utils:file_path("test/examples/base/books.xml"),
     ?assertEqual({error, invalid_pem}, signerl:sign(RawMessage, sha256, InvalidPemPath)).
+
+sign4_returns_file_error_with_missing_message_file(Config) ->
+    RsaKey = ?config(rsa_key, Config),
+    ?assertMatch(
+        {error, {file_error, enoent}},
+        signerl:sign("nonexistent_file.xml", sha256, RsaKey, <<"cert">>)
+    ).
+
+sign4_returns_file_error_with_missing_key_file(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    ?assertMatch(
+        {error, {file_error, enoent}},
+        signerl:sign(RawMessage, sha256, "nonexistent_key.pem", <<"cert">>)
+    ).
 
 verify_missing_prolog_binary_returns_error(Config) ->
     PublicKey = ?config(rsa_public_key, Config),
@@ -617,6 +701,20 @@ verify_reference_digests_returns_error_with_invalid_c14n_algorithm(Config) ->
         signerl_verify:verify_reference_digests(BrokenData, sha256)
     ).
 
+verify_reference_digests_accepts_exc_c14n_algorithm(Config) ->
+    %% Exc-C14N is a supported algorithm — verify_reference_digests should not error
+    %% on the algorithm check (digests will mismatch since message was signed with c14n11).
+    SignatureData = ?config(signature_data, Config),
+    SignatureElement = maps:get(signature_element, SignatureData),
+    ExcSignature = replace_c14n_algorithm(
+        SignatureElement, "http://www.w3.org/2001/10/xml-exc-c14n#"
+    ),
+    Message = message_with_signature(ExcSignature),
+    {ok, ExcData} = signerl_verify:extract_signature_data(Message),
+    Result = signerl_verify:verify_reference_digests(ExcData, sha256),
+    %% Should return false (digest mismatch) not {error, ...} since exc_c14n is valid
+    ?assertEqual(false, Result).
+
 verify_reference_digests_returns_error_with_invalid_signature_method_algorithm(Config) ->
     SignatureData = ?config(signature_data, Config),
     SignatureElement = maps:get(signature_element, SignatureData),
@@ -741,6 +839,110 @@ xades_xml_returns_error_with_non_signature_input(_Config) ->
         {error, missing_element},
         signerl_xades_xml:find_signed_properties_element(InvalidElement)
     ).
+
+%%%%%%%%%%%%%%%%%%%%%%%
+%%% KEYINFO GROUP TESTS
+%%%%%%%%%%%%%%%%%%%%%%%
+
+sign_with_certificate_includes_keyinfo(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey, RsaCertDer),
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    ?assertMatch(
+        {ok, {'ds:KeyInfo', _, _}},
+        signerl_xml:find_path(['ds:Signature', 'ds:KeyInfo'], Parsed)
+    ),
+    ?assertMatch(
+        {ok, {'ds:X509Certificate', _, [_]}},
+        signerl_xml:find_path(
+            ['ds:Signature', 'ds:KeyInfo', 'ds:X509Data', 'ds:X509Certificate'], Parsed
+        )
+    ).
+
+sign_without_certificate_omits_keyinfo(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey),
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    ?assertEqual(
+        {error, not_found},
+        signerl_xml:find_path(['ds:Signature', 'ds:KeyInfo'], Parsed)
+    ).
+
+sign_with_certificate_roundtrip_rsa(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    RsaPublicKey = ?config(rsa_public_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey, RsaCertDer),
+    ?assertEqual(true, signerl:verify(SignedMessage, sha256, RsaPublicKey)).
+
+sign_with_certificate_roundtrip_ecdsa(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    EcdsaKey = ?config(ecdsa_key, Config),
+    EcdsaCertDer = ?config(ecdsa_cert_der, Config),
+    EcdsaPublicKey = ?config(ecdsa_public_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, EcdsaKey, EcdsaCertDer),
+    ?assertEqual(true, signerl:verify(SignedMessage, sha256, EcdsaPublicKey)).
+
+verify_extracts_certificate_from_keyinfo(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey, RsaCertDer),
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    {ok, #{key_info := KeyInfo}} = signerl_verify:extract_signature_data(Parsed),
+    ?assertMatch(#{x509_certificate := RsaCertDer}, KeyInfo).
+
+sign_with_certificate_from_key_file(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKeyPath = ?config(rsa_key_path, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    RsaPublicKey = ?config(rsa_public_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKeyPath, RsaCertDer),
+    ?assertEqual(true, signerl:verify(SignedMessage, sha256, RsaPublicKey)).
+
+sign_with_certificate_from_message_file(Config) ->
+    MessagePath = ?config(message_path, Config),
+    RsaKey = ?config(rsa_key, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    RsaPublicKey = ?config(rsa_public_key, Config),
+    SignedMessage = signerl:sign(MessagePath, sha256, RsaKey, RsaCertDer),
+    ?assertEqual(true, signerl:verify(SignedMessage, sha256, RsaPublicKey)).
+
+verify_extracts_no_keyinfo_when_absent(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey),
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    {ok, #{key_info := KeyInfo}} = signerl_verify:extract_signature_data(Parsed),
+    ?assertEqual(undefined, KeyInfo).
+
+%%%%%%%%%%%%%%%%%%%%%%%
+%%% INTEROP SMOKE GROUP TESTS
+%%%%%%%%%%%%%%%%%%%%%%%
+
+c14n_idempotent_after_sign(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey),
+    {ok, ParsedSigned} = signerl_xml:parse_binary(SignedMessage),
+    {ok, SignedInfoElement} = signerl_xml:find_path(
+        ['ds:Signature', 'ds:SignedInfo'], ParsedSigned
+    ),
+    C14N1 = signerl_c14n:canonicalize(SignedInfoElement),
+    {ok, ReParsed} = signerl_xml:parse_binary(C14N1),
+    C14N2 = signerl_c14n:canonicalize(ReParsed),
+    ?assertEqual(C14N1, C14N2).
+
+is_signature_element_shared(_Config) ->
+    SigElement = {'ds:Signature', [], []},
+    NonSigElement = {'ds:SignedInfo', [], []},
+    ?assertEqual(true, signerl_xml:is_signature_element(SigElement)),
+    ?assertEqual(false, signerl_xml:is_signature_element(NonSigElement)),
+    ?assertEqual(false, signerl_xml:is_signature_element("text")).
 
 compute_valid_signature_data() ->
     MessagePath = signerl_utils:file_path("test/examples/base/books.xml"),
@@ -924,3 +1126,40 @@ assert_has_signed_info(SignatureElement) ->
     ?assertMatch(
         {ok, {'ds:SignedInfo', _, _}}, signerl_xml:find_path(['ds:SignedInfo'], SignatureElement)
     ).
+
+c14n_mode_returns_exc_for_exc_c14n_algorithm(_Config) ->
+    SigData = #{references => #{c14n_algorithm => "http://www.w3.org/2001/10/xml-exc-c14n#"}},
+    ?assertEqual(exc_c14n, signerl_verify:c14n_mode(SigData)),
+    SigDataC14N11 = #{references => #{c14n_algorithm => "http://www.w3.org/2006/12/xml-c14n11"}},
+    ?assertEqual(c14n11, signerl_verify:c14n_mode(SigDataC14N11)).
+
+extract_x509_certificate_returns_undefined_for_invalid_cert(_Config) ->
+    %% Sign a message with certificate, then corrupt the cert to test error paths.
+    MessagePath = signerl_utils:file_path("test/examples/base/books.xml"),
+    {ok, RawMessage} = file:read_file(MessagePath),
+    RsaKey = signerl_cert_helpers:signer_rsa_key(),
+    RsaCertDer = test_helpers:cert_der(signerl_cert_helpers:signer_rsa_cert_path()),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey, RsaCertDer),
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    %% Test 1: Corrupt cert to invalid structure (multiple children → _ catch-all)
+    CorruptedStructure = corrupt_x509_certificate(Parsed, [<<"binary">>, <<"extra">>]),
+    {ok, #{key_info := KeyInfo1}} = signerl_verify:extract_signature_data(CorruptedStructure),
+    ?assertEqual(undefined, KeyInfo1),
+    %% Test 2: Corrupt cert to invalid base64 (single list child → decode error)
+    CorruptedBase64 = corrupt_x509_certificate(Parsed, ["!!!not-base64!!!"]),
+    {ok, #{key_info := KeyInfo2}} = signerl_verify:extract_signature_data(CorruptedBase64),
+    ?assertEqual(undefined, KeyInfo2).
+
+corrupt_x509_certificate({Tag, Attrs, Children}, Replacement) ->
+    {Tag, Attrs, [corrupt_x509_certificate_child(C, Replacement) || C <- Children]}.
+
+corrupt_x509_certificate_child({'ds:Signature', Attrs, Content}, Replacement) ->
+    {'ds:Signature', Attrs, [corrupt_x509_certificate_child(C, Replacement) || C <- Content]};
+corrupt_x509_certificate_child({'ds:KeyInfo', Attrs, Content}, Replacement) ->
+    {'ds:KeyInfo', Attrs, [corrupt_x509_certificate_child(C, Replacement) || C <- Content]};
+corrupt_x509_certificate_child({'ds:X509Data', Attrs, Content}, Replacement) ->
+    {'ds:X509Data', Attrs, [corrupt_x509_certificate_child(C, Replacement) || C <- Content]};
+corrupt_x509_certificate_child({'ds:X509Certificate', Attrs, _}, Replacement) ->
+    {'ds:X509Certificate', Attrs, Replacement};
+corrupt_x509_certificate_child(Other, _Replacement) ->
+    Other.

--- a/test/signerl_c14n_SUITE.erl
+++ b/test/signerl_c14n_SUITE.erl
@@ -10,6 +10,7 @@ all() ->
         {group, namespace_group},
         {group, escaping_group},
         {group, transform_group},
+        {group, exc_c14n_group},
         {group, interop_group}
     ].
 
@@ -49,6 +50,16 @@ groups() ->
             remove_signature_from_root,
             remove_signature_preserves_other_children,
             remove_signature_no_signature_present
+        ]},
+        {exc_c14n_group, [], [
+            exc_c14n_omits_unused_ns,
+            exc_c14n_keeps_visibly_used_ns,
+            exc_c14n_propagates_ns_to_children,
+            exc_c14n_binary_text_child,
+            exc_c14n_default_namespace,
+            exc_c14n_ns_already_in_output_scope,
+            c14n11_emits_all_ns_decls,
+            canonicalize_1_defaults_to_c14n11
         ]},
         {interop_group, [], [
             interop_simple_attrs,
@@ -297,6 +308,86 @@ remove_signature_no_signature_present(_Config) ->
     Input = {root, [], [{child, [], ["text"]}]},
     ?assertEqual(Input, signerl_c14n:remove_signature_elements(Input)).
 
+%% === Exclusive C14N Group ===
+
+exc_c14n_omits_unused_ns(_Config) ->
+    %% Parent declares ns1 and ns2, child only uses ns1 in tag.
+    %% Exc-C14N: root emits neither (not visibly used), child emits ns1.
+    Input = two_ns_input(),
+    Result = signerl_c14n:canonicalize(Input, exc_c14n),
+    ?assertEqual(
+        <<"<root><ns1:child xmlns:ns1=\"http://ns1\">text</ns1:child></root>">>,
+        Result
+    ).
+
+exc_c14n_keeps_visibly_used_ns(_Config) ->
+    %% Child uses ns1 in tag and ns2 in attribute — both should be emitted.
+    Input =
+        {root, [{'xmlns:ns1', "http://ns1"}, {'xmlns:ns2', "http://ns2"}], [
+            {'ns1:child', [{'ns2:attr', "val"}], ["text"]}
+        ]},
+    Result = signerl_c14n:canonicalize(Input, exc_c14n),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"xmlns:ns1=\"http://ns1\"">>)),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"xmlns:ns2=\"http://ns2\"">>)).
+
+exc_c14n_propagates_ns_to_children(_Config) ->
+    %% Grandchild uses ns1 but parent doesn't — exc-c14n should emit ns1 on grandchild.
+    Input =
+        {root, [{'xmlns:ns1', "http://ns1"}], [
+            {middle, [], [
+                {'ns1:leaf', [], ["deep"]}
+            ]}
+        ]},
+    Result = signerl_c14n:canonicalize(Input, exc_c14n),
+    ?assertNotEqual(
+        nomatch, binary:match(Result, <<"<ns1:leaf xmlns:ns1=\"http://ns1\">deep</ns1:leaf>">>)
+    ).
+
+c14n11_emits_all_ns_decls(_Config) ->
+    %% C14N 1.1 should emit ns2 on root even if only used by descendants.
+    Input = two_ns_input(),
+    C14N11 = signerl_c14n:canonicalize(Input, c14n11),
+    %% ns2 should appear on root but NOT re-emitted on child
+    ?assertNotEqual(nomatch, binary:match(C14N11, <<"xmlns:ns2=\"http://ns2\"">>)),
+    %% Verify ns2 is NOT on child element in C14N 1.1
+    ChildPart =
+        case binary:match(C14N11, <<"<ns1:child">>) of
+            {Start, _} -> binary:part(C14N11, Start, byte_size(C14N11) - Start);
+            nomatch -> <<>>
+        end,
+    ?assertEqual(nomatch, binary:match(ChildPart, <<"xmlns:ns2">>)).
+
+canonicalize_1_defaults_to_c14n11(_Config) ->
+    Input = {root, [{'xmlns:ns1', "http://ns1"}], [{'ns1:child', [], ["text"]}]},
+    ?assertEqual(
+        signerl_c14n:canonicalize(Input, c14n11),
+        signerl_c14n:canonicalize(Input)
+    ).
+
+exc_c14n_binary_text_child(_Config) ->
+    %% Binary text child should be handled the same as list text.
+    Input = {root, [], [<<"binary text">>]},
+    ?assertEqual(<<"<root>binary text</root>">>, signerl_c14n:canonicalize(Input, exc_c14n)).
+
+exc_c14n_default_namespace(_Config) ->
+    %% Element using default namespace (no prefix) should emit xmlns="...".
+    Input = {child, [{xmlns, "http://default"}], ["text"]},
+    Result = signerl_c14n:canonicalize(Input, exc_c14n),
+    ?assertEqual(<<"<child xmlns=\"http://default\">text</child>">>, Result).
+
+exc_c14n_ns_already_in_output_scope(_Config) ->
+    %% When parent already emitted ns1, child should not re-emit it (NeedEmit=false path).
+    Input =
+        {'ns1:parent', [{'xmlns:ns1', "http://ns1"}], [
+            {'ns1:child', [], ["text"]}
+        ]},
+    Result = signerl_c14n:canonicalize(Input, exc_c14n),
+    %% ns1 appears once on parent, not re-emitted on child
+    ?assertEqual(
+        <<"<ns1:parent xmlns:ns1=\"http://ns1\"><ns1:child>text</ns1:child></ns1:parent>">>,
+        Result
+    ).
+
 %% === Interop Group ===
 %% Compare our C14N 1.1 output against xmllint --c14n11
 
@@ -357,3 +448,8 @@ run_our_c14n(FilePath) ->
     {ParsedXml, _} = xmerl_scan:file(FilePath),
     Simplified = xmerl_lib:simplify_element(ParsedXml),
     signerl_c14n:canonicalize(Simplified).
+
+two_ns_input() ->
+    {root, [{'xmlns:ns1', "http://ns1"}, {'xmlns:ns2', "http://ns2"}], [
+        {'ns1:child', [], ["text"]}
+    ]}.

--- a/test/test_helpers.erl
+++ b/test/test_helpers.erl
@@ -3,6 +3,7 @@
 -export([
     rsa_public_key_from_cert/1,
     ecdsa_public_key_from_cert/1,
+    cert_der/1,
     signature_element/1
 ]).
 
@@ -34,6 +35,12 @@ ecdsa_public_key_from_cert(CertPath) ->
     Params = Alg#'PublicKeyAlgorithm'.parameters,
     PointRec = Spki#'OTPSubjectPublicKeyInfo'.subjectPublicKey,
     {PointRec, Params}.
+
+cert_der(CertPath) ->
+    {ok, CertRaw} = file:read_file(CertPath),
+    [PemEntry] = public_key:pem_decode(CertRaw),
+    {_, Der, _} = PemEntry,
+    Der.
 
 signature_element(SignedSignaturePropertiesElements) ->
     {'ds:Signature', [], [


### PR DESCRIPTION
## Summary

Completes all remaining Phase 1 roadmap items:

### Changes
- **`sign/4` with KeyInfo**: New API accepting optional `CertDer` binary to embed X.509 certificate in `ds:KeyInfo > ds:X509Data > ds:X509Certificate`
- **Exclusive C14N (#35)**: Separate `exc_element/3` code path with proper visible utilization tracking via `exc_needed_decls/3`
- **Dedup `is_signature_element/1`**: Consolidated from `signerl_verify` and `signerl_c14n` to `signerl_xml`
- **Verification auto-detects C14N mode**: `c14n_mode/1` resolves from signature's `CanonicalizationMethod` algorithm URI
- **KeyInfo extraction**: `extract_key_info/1` and `extract_x509_certificate/1` in verify module

### Quality Gates
| Gate | Result |
|------|--------|
| `rebar3 eunit` | 14 tests, 0 failures |
| `rebar3 ct` | 124 tests (was 101), 0 failures |
| `rebar3 as test cover` | **100%** total coverage |
| `rebar3 flint` | Clean |
| `rebar3 dialyzer` | Clean |

Closes #35