### PR TITLE
Implement SigningCertificateV2 property

### DIFF
--- a/docs/implementations/signing_certificate_v2.md
+++ b/docs/implementations/signing_certificate_v2.md
@@ -1,0 +1,62 @@
+# SigningCertificateV2 Property (Issue #36)
+
+## What Changed
+
+### New module: `src/signerl_cert.erl`
+Certificate operations for XAdES SigningCertificateV2:
+- `cert_digest_base64/2` — computes `base64(hash(CertDER))` for a given hash algorithm
+- `issuer_serial_v2_base64/1` — encodes `IssuerSerial` (RFC 5035) as `base64(DER(SEQUENCE{GeneralNames, CertificateSerialNumber}))` using manual DER encoding (OTP lacks the `IssuerSerial` ASN.1 type)
+
+### Modified: `src/signerl_signature.erl`
+- `signed_properties/1` → `signed_properties/4` now accepts `HashAlgorithm`, `DigestMethodUri`, and `CertDer`
+- Added `signing_certificate_v2_elements/3` to emit the `xades:SigningCertificateV2` XML element when `CertDer` is provided; returns `[]` when `CertDer` is `undefined` (backward compat)
+
+### Modified: `src/signerl_signed_properties.erl`
+- Replaced placeholder `SigningCertificateV2` validator with full structural validation
+- `validate_signing_certificate_v2/1` parses `xades:Cert > xades:CertDigest` (digest method + value) and optional `xades:IssuerSerialV2`
+- Returns structured map: `#{digest_method, digest_value, issuer_serial_v2?}`
+- Added helpers: `validate_cert_element/1`, `extract_cert_digest/1`, `validate_cert_digest/1`, `extract_issuer_serial_v2/1`, `find_element/2`, `decode_base64_text/1`, `decode_base64_value/1`
+
+### Modified: `src/signerl_verify.erl`
+- Added `verify_cert_digest/3` with three clauses:
+  1. Both `SigningCertificateV2` and `KeyInfo` cert present → cross-check digest
+  2. `SigningCertificateV2` present but no `KeyInfo` cert → pass (can't verify)
+  3. No `SigningCertificateV2` → pass (backward compat)
+- `verify_reference_digests` pattern now includes `signed_properties` and `key_info` fields
+- `else` clause propagates `{error, cert_digest_mismatch}` specifically
+
+### Modified: `elvis.config`
+- Added `signerl_cert` to `atom_naming_convention` ignore list (uses OTP ASN.1 record field names like `tbsCertificate`, `serialNumber`)
+
+### Modified: `scripts/gen_certs.sh`
+- Added step 8: generates `high_serial.cert.pem` with serial 0xFF for DER integer padding coverage
+
+### New test cert: `priv/certs/high_serial.cert.pem` / `high_serial.key.pem`
+- Self-signed RSA cert with serial number 255 (0xFF) — exercises DER integer high-bit padding branch
+
+### Test changes
+- `test/signerl_signed_properties_SUITE.erl`: 13 → 20 tests (+7 edge-case tests for decode_base64, find_element, invalid issuer serial, missing digest method, binary values)
+- `test/signerl_SUITE.erl`: added 6 tests to `keyinfo_group` (cert v2 presence, absence, digest extraction, high-serial encoding, cert-v2-without-keyinfo, mismatched digest method)
+- `test/signerl_cert_helpers.erl`: added `high_serial_cert_path/0`
+
+## Why This Solves the Task
+
+XAdES Baseline-B requires `SigningCertificateV2` to cryptographically bind the signature to a specific certificate. This implementation:
+- **Builds** the element during signing (`sign/4` path) using the same hash algorithm as the signature
+- **Validates** the element during verification by cross-checking the embedded cert digest against the actual certificate from `KeyInfo`
+- **Preserves backward compatibility**: `sign/3` (no cert) omits the element; verification passes when the element is absent
+- Follows RFC 5035 for `IssuerSerial` DER encoding
+
+## Validation
+
+| Gate | Result |
+|------|--------|
+| `rebar3 eunit` | 14 tests, 0 failures |
+| `rebar3 ct` | 149 tests, 0 failures |
+| `rebar3 as test cover` | 100% total coverage |
+| `rebar3 flint` | Clean |
+| `rebar3 dialyzer` | Clean |
+
+## Documentation
+
+No public API changes (`sign/4` and `verify/3` signatures unchanged). The `SigningCertificateV2` element is automatically included/validated when a certificate is provided. No README update required.

--- a/elvis.config
+++ b/elvis.config
@@ -4,7 +4,8 @@
        filter => "*.erl",
        ruleset => erl_files,
        rules => [
-           {elvis_style, private_data_types, #{ignore => [signerl_xml]}}
+           {elvis_style, private_data_types, #{ignore => [signerl_xml]}},
+           {elvis_style, atom_naming_convention, #{ignore => [signerl_cert]}}
        ]},
      #{dirs => ["test"],
        filter => "*.erl",

--- a/scripts/gen_certs.sh
+++ b/scripts/gen_certs.sh
@@ -101,4 +101,12 @@ openssl req -new -x509 -days 825 -key signer_ecdsa.key.pem -out signer_ecdsa.cer
   -subj "/C=US/ST=State/L=City/O=SignerL Test/OU=Signer/CN=SignerL Self-Signed ECDSA" \
   -extensions v3_signer_only
 
+# 8) Self-signed RSA cert with high serial (0xFF) — tests DER integer padding
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out high_serial.key.pem
+openssl req -new -x509 -days 36500 -key high_serial.key.pem -out high_serial.cert.pem \
+  -set_serial 255 \
+  -config openssl.cnf \
+  -subj "/C=US/ST=State/L=City/O=SignerL Test/OU=Signer/CN=HighSerial Test" \
+  -extensions v3_signer_only
+
 echo "Done. Generated test certs in $OUT_DIR"

--- a/src/signerl_cert.erl
+++ b/src/signerl_cert.erl
@@ -1,0 +1,44 @@
+-module(signerl_cert).
+
+-include_lib("public_key/include/OTP-PUB-KEY.hrl").
+
+-export([cert_digest_base64/2, issuer_serial_v2_base64/1]).
+
+-spec cert_digest_base64(HashAlgorithm, CertDer) -> binary() when
+    HashAlgorithm :: atom(),
+    CertDer :: binary().
+cert_digest_base64(HashAlgorithm, CertDer) ->
+    base64:encode(crypto:hash(HashAlgorithm, CertDer)).
+
+-spec issuer_serial_v2_base64(CertDer) -> binary() when
+    CertDer :: binary().
+issuer_serial_v2_base64(CertDer) ->
+    Cert = public_key:pkix_decode_cert(CertDer, plain),
+    TBS = Cert#'Certificate'.tbsCertificate,
+    Issuer = TBS#'TBSCertificate'.issuer,
+    Serial = TBS#'TBSCertificate'.serialNumber,
+    GeneralNamesDer = public_key:der_encode('GeneralNames', [{directoryName, Issuer}]),
+    SerialDer = der_encode_integer(Serial),
+    IssuerSerialDer = der_encode_sequence(<<GeneralNamesDer/binary, SerialDer/binary>>),
+    base64:encode(IssuerSerialDer).
+
+%% ASN.1 DER encoding helpers for IssuerSerial (RFC 5035).
+%% OTP does not include this type, so we encode manually.
+
+der_encode_integer(N) when N >= 0 ->
+    Raw = binary:encode_unsigned(N),
+    Padded =
+        case Raw of
+            <<1:1, _/bitstring>> -> <<0, Raw/binary>>;
+            _ -> Raw
+        end,
+    <<2, (der_encode_length(byte_size(Padded)))/binary, Padded/binary>>.
+
+der_encode_sequence(Contents) ->
+    <<16#30, (der_encode_length(byte_size(Contents)))/binary, Contents/binary>>.
+
+der_encode_length(Len) when Len < 128 ->
+    <<Len>>;
+der_encode_length(Len) ->
+    Bytes = binary:encode_unsigned(Len),
+    <<(128 + byte_size(Bytes)), Bytes/binary>>.

--- a/src/signerl_signature.erl
+++ b/src/signerl_signature.erl
@@ -38,7 +38,7 @@ construct_signature_without_value(
     Message, HashAlgorithm, DigestMethodUri, SignatureMethodUri, CertDer
 ) ->
     SigningTime = signerl_utils:current_utc_timestamp(),
-    SignedProperties = signed_properties(SigningTime),
+    SignedProperties = signed_properties(SigningTime, HashAlgorithm, DigestMethodUri, CertDer),
     SignedInfo = signed_info(
         Message, SignedProperties, HashAlgorithm, DigestMethodUri, SignatureMethodUri
     ),
@@ -109,9 +109,26 @@ signature_object(SignedProperties) ->
             [SignedProperties]}
     ]}.
 
-signed_properties(SigningTime) ->
+signed_properties(SigningTime, HashAlgorithm, DigestMethodUri, CertDer) ->
+    SigningTimeElement = {'xades:SigningTime', [], [binary_to_list(SigningTime)]},
+    CertElements = signing_certificate_v2_elements(HashAlgorithm, DigestMethodUri, CertDer),
     {'xades:SignedProperties', [{'Id', ?SIGNED_PROPERTIES_ID}], [
-        {'xades:SignedSignatureProperties', [], [
-            {'xades:SigningTime', [], [binary_to_list(SigningTime)]}
-        ]}
+        {'xades:SignedSignatureProperties', [], [SigningTimeElement | CertElements]}
     ]}.
+
+signing_certificate_v2_elements(_HashAlgorithm, _DigestMethodUri, undefined) ->
+    [];
+signing_certificate_v2_elements(HashAlgorithm, DigestMethodUri, CertDer) ->
+    CertDigestB64 = signerl_cert:cert_digest_base64(HashAlgorithm, CertDer),
+    IssuerSerialB64 = signerl_cert:issuer_serial_v2_base64(CertDer),
+    [
+        {'xades:SigningCertificateV2', [], [
+            {'xades:Cert', [], [
+                {'xades:CertDigest', [], [
+                    {'ds:DigestMethod', [{'Algorithm', DigestMethodUri}], []},
+                    {'ds:DigestValue', [], [binary_to_list(CertDigestB64)]}
+                ]},
+                {'xades:IssuerSerialV2', [], [binary_to_list(IssuerSerialB64)]}
+            ]}
+        ]}
+    ].

--- a/src/signerl_signed_properties.erl
+++ b/src/signerl_signed_properties.erl
@@ -1,4 +1,5 @@
 -module(signerl_signed_properties).
+-feature(maybe_expr, enable).
 
 -export([extract/1]).
 
@@ -36,9 +37,13 @@ validate_signed_property({'xades:SigningTime', _, _} = SigningTimeElement, Signe
 validate_signed_property({'xades:SigningCertificate', _, _}, SignedProperties) ->
     %% TODO: validate certificate content (structural presence check only)
     put_unique_property(signing_certificate, present, SignedProperties);
-validate_signed_property({'xades:SigningCertificateV2', _, _}, SignedProperties) ->
-    %% TODO: validate certificate v2 content (structural presence check only)
-    put_unique_property(signing_certificate_v2, present, SignedProperties);
+validate_signed_property({'xades:SigningCertificateV2', _, Content}, SignedProperties) ->
+    case validate_signing_certificate_v2(Content) of
+        {ok, CertInfo} ->
+            put_unique_property(signing_certificate_v2, CertInfo, SignedProperties);
+        {error, _} = Err ->
+            Err
+    end;
 validate_signed_property({'xades:SignaturePolicyIdentifier', _, _}, SignedProperties) ->
     %% TODO: validate policy identifier content (structural presence check only)
     put_unique_property(signature_policy_identifier, present, SignedProperties);
@@ -79,4 +84,73 @@ decode_signing_time_binary(SigningTime) when is_binary(SigningTime) ->
     case signerl_utils:valid_utc_timestamp(SigningTime) of
         true -> {ok, SigningTime};
         false -> {error, invalid_signing_time}
+    end.
+
+validate_signing_certificate_v2([{'xades:Cert', _, CertContent}]) ->
+    validate_cert_element(CertContent);
+validate_signing_certificate_v2(_) ->
+    {error, invalid_signing_certificate_v2}.
+
+validate_cert_element(Content) ->
+    maybe
+        {ok, CertDigest} ?= extract_cert_digest(Content),
+        IssuerSerial = extract_issuer_serial_v2(Content),
+        {ok, maps:merge(CertDigest, IssuerSerial)}
+    end.
+
+extract_cert_digest(Content) ->
+    case lists:keyfind('xades:CertDigest', 1, Content) of
+        {'xades:CertDigest', _, DigestContent} ->
+            validate_cert_digest(DigestContent);
+        false ->
+            {error, invalid_signing_certificate_v2}
+    end.
+
+validate_cert_digest(DigestContent) ->
+    maybe
+        {ok, {'ds:DigestMethod', DigestMethodAttrs, _}} ?=
+            find_element('ds:DigestMethod', DigestContent),
+        {ok, DigestMethodUri} ?= signerl_xml:attr_value('Algorithm', DigestMethodAttrs),
+        {ok, {'ds:DigestValue', _, [DigestValueText]}} ?=
+            find_element('ds:DigestValue', DigestContent),
+        {ok, DigestValue} ?= decode_base64_text(DigestValueText),
+        {ok, #{digest_method => DigestMethodUri, digest_value => DigestValue}}
+    else
+        _ -> {error, invalid_signing_certificate_v2}
+    end.
+
+extract_issuer_serial_v2(Content) ->
+    case lists:keyfind('xades:IssuerSerialV2', 1, Content) of
+        {'xades:IssuerSerialV2', _, [IssuerSerialText]} ->
+            case decode_base64_text(IssuerSerialText) of
+                {ok, IssuerSerialDer} -> #{issuer_serial_v2 => IssuerSerialDer};
+                {error, _} -> #{}
+            end;
+        _ ->
+            #{}
+    end.
+
+find_element(Tag, Content) ->
+    case lists:keyfind(Tag, 1, Content) of
+        false -> {error, not_found};
+        Element -> {ok, Element}
+    end.
+
+decode_base64_text(Text) when is_binary(Text) ->
+    decode_base64_value(Text);
+decode_base64_text(Text) when is_list(Text) ->
+    case signerl_utils:is_byte_list(Text) of
+        true -> decode_base64_value(list_to_binary(Text));
+        false -> {error, invalid_base64}
+    end;
+decode_base64_text(_) ->
+    {error, invalid_base64}.
+
+decode_base64_value(<<>>) ->
+    {error, invalid_base64};
+decode_base64_value(Value) ->
+    try
+        {ok, base64:decode(Value)}
+    catch
+        _:_ -> {error, invalid_base64}
     end.

--- a/src/signerl_verify.erl
+++ b/src/signerl_verify.erl
@@ -26,12 +26,14 @@ verify_reference_digests(
     #{
         unsigned_message := UnsignedMessage,
         signature_element := SignatureElement,
+        signed_properties := SignedProperties,
         references := #{
             document := #{digest_value := DocumentDigestValue} = DocumentReference,
             signed_properties := #{
                 digest_value := SignedPropertiesDigestValue
             } = SignedPropertiesReference
-        } = References
+        } = References,
+        key_info := KeyInfo
     },
     HashAlgorithm
 ) ->
@@ -41,6 +43,7 @@ verify_reference_digests(
         ok ?= validate_signed_info_algorithms(References, SignatureMethodUris),
         ok ?= validate_document_reference(DocumentReference, DigestMethodUri),
         ok ?= validate_signed_properties_reference(SignedPropertiesReference, DigestMethodUri),
+        ok ?= verify_cert_digest(SignedProperties, KeyInfo, HashAlgorithm),
         {ok, SignedPropertiesElement} ?=
             signerl_xades_xml:find_signed_properties_element(SignatureElement),
         DocumentPayload = signerl_c14n:canonicalize(
@@ -61,6 +64,8 @@ verify_reference_digests(
                 false
         end
     else
+        {error, cert_digest_mismatch} ->
+            {error, cert_digest_mismatch};
         _ ->
             {error, invalid_signature_structure}
     end;
@@ -285,3 +290,27 @@ extract_x509_certificate(KeyInfoElement) ->
     else
         _ -> undefined
     end.
+
+verify_cert_digest(
+    #{
+        signing_certificate_v2 := #{
+            digest_method := DigestMethodUri, digest_value := ExpectedDigest
+        }
+    },
+    #{x509_certificate := CertDer},
+    HashAlgorithm
+) ->
+    case digest_method_uri(HashAlgorithm) of
+        {ok, DigestMethodUri} ->
+            ActualDigest = crypto:hash(HashAlgorithm, CertDer),
+            case ActualDigest =:= ExpectedDigest of
+                true -> ok;
+                false -> {error, cert_digest_mismatch}
+            end;
+        _ ->
+            {error, cert_digest_mismatch}
+    end;
+verify_cert_digest(#{signing_certificate_v2 := _}, undefined, _HashAlgorithm) ->
+    ok;
+verify_cert_digest(_SignedProperties, _KeyInfo, _HashAlgorithm) ->
+    ok.

--- a/test/signerl_SUITE.erl
+++ b/test/signerl_SUITE.erl
@@ -101,7 +101,14 @@ groups() ->
             sign_with_certificate_from_key_file,
             sign_with_certificate_from_message_file,
             verify_extracts_certificate_from_keyinfo,
-            verify_extracts_no_keyinfo_when_absent
+            verify_extracts_no_keyinfo_when_absent,
+            sign_with_certificate_includes_signing_certificate_v2,
+            sign_without_certificate_omits_signing_certificate_v2,
+            sign_with_certificate_extracts_cert_digest,
+            sign_with_high_serial_cert_encodes_issuer_serial,
+            verify_fails_with_tampered_cert_digest,
+            verify_succeeds_with_cert_v2_but_no_keyinfo_cert,
+            verify_fails_with_mismatched_cert_digest_method
         ]},
         {interop_smoke_group, [], [
             c14n_idempotent_after_sign,
@@ -202,6 +209,7 @@ init_per_group(keyinfo_group, Config) ->
     EcdsaKey = signerl_cert_helpers:signer_ecdsa_key(),
     RsaCertDer = test_helpers:cert_der(signerl_cert_helpers:signer_rsa_cert_path()),
     EcdsaCertDer = test_helpers:cert_der(signerl_cert_helpers:signer_ecdsa_cert_path()),
+    HighSerialCertDer = test_helpers:cert_der(signerl_cert_helpers:high_serial_cert_path()),
     RsaPublicKey = test_helpers:rsa_public_key_from_cert(
         signerl_cert_helpers:signer_rsa_cert_path()
     ),
@@ -217,6 +225,7 @@ init_per_group(keyinfo_group, Config) ->
         {ecdsa_key, EcdsaKey},
         {rsa_cert_der, RsaCertDer},
         {ecdsa_cert_der, EcdsaCertDer},
+        {high_serial_cert_der, HighSerialCertDer},
         {rsa_public_key, RsaPublicKey},
         {ecdsa_public_key, EcdsaPublicKey}
         | Config
@@ -927,6 +936,165 @@ verify_extracts_no_keyinfo_when_absent(Config) ->
     {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
     {ok, #{key_info := KeyInfo}} = signerl_verify:extract_signature_data(Parsed),
     ?assertEqual(undefined, KeyInfo).
+
+signing_certificate_v2_path() ->
+    [
+        'ds:Signature',
+        'ds:Object',
+        'xades:QualifyingProperties',
+        'xades:SignedProperties',
+        'xades:SignedSignatureProperties',
+        'xades:SigningCertificateV2'
+    ].
+
+sign_with_certificate_includes_signing_certificate_v2(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey, RsaCertDer),
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    ?assertMatch(
+        {ok, {'xades:SigningCertificateV2', _, _}},
+        signerl_xml:find_path(signing_certificate_v2_path(), Parsed)
+    ).
+
+sign_without_certificate_omits_signing_certificate_v2(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey),
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    ?assertEqual(
+        {error, not_found},
+        signerl_xml:find_path(signing_certificate_v2_path(), Parsed)
+    ).
+
+sign_with_certificate_extracts_cert_digest(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey, RsaCertDer),
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    {ok, #{signed_properties := SignedProps}} = signerl_verify:extract_signature_data(Parsed),
+    #{signing_certificate_v2 := CertV2} = SignedProps,
+    ExpectedDigest = crypto:hash(sha256, RsaCertDer),
+    ?assertEqual(ExpectedDigest, maps:get(digest_value, CertV2)),
+    ?assertEqual("http://www.w3.org/2001/04/xmlenc#sha256", maps:get(digest_method, CertV2)),
+    ?assert(maps:is_key(issuer_serial_v2, CertV2)).
+
+verify_fails_with_tampered_cert_digest(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    RsaPublicKey = ?config(rsa_public_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey, RsaCertDer),
+    %% Tamper with the cert digest by replacing the certificate in KeyInfo
+    %% with a different one. The cert digest in SignedProperties won't match.
+    EcdsaCertDer = ?config(ecdsa_cert_der, Config),
+    TamperedMessage = tamper_keyinfo_certificate(SignedMessage, EcdsaCertDer),
+    ?assertEqual(
+        {error, cert_digest_mismatch},
+        signerl:verify(TamperedMessage, sha256, RsaPublicKey)
+    ).
+
+tamper_keyinfo_certificate(SignedMessage, NewCertDer) ->
+    NewCertB64 = binary_to_list(base64:encode(NewCertDer)),
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    Tampered = replace_x509_certificate(Parsed, NewCertB64),
+    signerl_xml:export(<<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>">>, Tampered).
+
+replace_x509_certificate({'ds:X509Certificate', Attrs, _}, NewCertB64) ->
+    {'ds:X509Certificate', Attrs, [NewCertB64]};
+replace_x509_certificate({Tag, Attrs, Content}, NewCertB64) when is_list(Content) ->
+    {Tag, Attrs, [replace_x509_certificate(Child, NewCertB64) || Child <- Content]};
+replace_x509_certificate(Other, _NewCertB64) ->
+    Other.
+
+sign_with_high_serial_cert_encodes_issuer_serial(Config) ->
+    HighSerialCertDer = ?config(high_serial_cert_der, Config),
+    Result = signerl_cert:issuer_serial_v2_base64(HighSerialCertDer),
+    ?assert(is_binary(Result)),
+    Decoded = base64:decode(Result),
+    %% Verify the DER is a SEQUENCE (tag 0x30)
+    ?assertMatch(<<16#30, _/binary>>, Decoded).
+
+verify_succeeds_with_cert_v2_but_no_keyinfo_cert(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    RsaPublicKey = ?config(rsa_public_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey, RsaCertDer),
+    %% Remove the X509Certificate element from KeyInfo while keeping
+    %% SigningCertificateV2 — verify should still succeed
+    StrippedMessage = strip_keyinfo_certificate(SignedMessage),
+    ?assertEqual(true, signerl:verify(StrippedMessage, sha256, RsaPublicKey)).
+
+verify_fails_with_mismatched_cert_digest_method(Config) ->
+    RawMessage = ?config(raw_message, Config),
+    RsaKey = ?config(rsa_key, Config),
+    RsaCertDer = ?config(rsa_cert_der, Config),
+    RsaPublicKey = ?config(rsa_public_key, Config),
+    SignedMessage = signerl:sign(RawMessage, sha256, RsaKey, RsaCertDer),
+    %% Tamper with the DigestMethod URI inside SigningCertificateV2
+    TamperedMessage = tamper_cert_digest_method(SignedMessage),
+    ?assertEqual(
+        {error, cert_digest_mismatch},
+        signerl:verify(TamperedMessage, sha256, RsaPublicKey)
+    ).
+
+strip_keyinfo_certificate(SignedMessage) ->
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    Stripped = remove_x509_data(Parsed),
+    signerl_xml:export(<<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>">>, Stripped).
+
+remove_x509_data({'ds:X509Data', _Attrs, _Content}) ->
+    removed;
+remove_x509_data({Tag, Attrs, Content}) when is_list(Content) ->
+    Filtered = lists:filtermap(
+        fun(Child) ->
+            case remove_x509_data(Child) of
+                removed -> false;
+                Transformed -> {true, Transformed}
+            end
+        end,
+        Content
+    ),
+    {Tag, Attrs, Filtered};
+remove_x509_data(Other) ->
+    Other.
+
+tamper_cert_digest_method(SignedMessage) ->
+    {ok, Parsed} = signerl_xml:parse_binary(SignedMessage),
+    Tampered = replace_cert_digest_method(Parsed),
+    signerl_xml:export(<<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>">>, Tampered).
+
+replace_cert_digest_method({'xades:SigningCertificateV2', Attrs, Content}) ->
+    {'xades:SigningCertificateV2', Attrs, replace_cert_digest_method_inner(Content)};
+replace_cert_digest_method({Tag, Attrs, Content}) when is_list(Content) ->
+    {Tag, Attrs, [replace_cert_digest_method(Child) || Child <- Content]};
+replace_cert_digest_method(Other) ->
+    Other.
+
+replace_cert_digest_method_inner([{'xades:Cert', CAttrs, CContent}]) ->
+    [{'xades:Cert', CAttrs, replace_digest_method_in_cert(CContent)}];
+replace_cert_digest_method_inner(Other) ->
+    Other.
+
+replace_digest_method_in_cert([]) ->
+    [];
+replace_digest_method_in_cert([{'xades:CertDigest', DAttrs, DContent} | Rest]) ->
+    [{'xades:CertDigest', DAttrs, replace_digest_method_elem(DContent)} | Rest];
+replace_digest_method_in_cert([H | T]) ->
+    [H | replace_digest_method_in_cert(T)].
+
+replace_digest_method_elem([]) ->
+    [];
+replace_digest_method_elem([{'ds:DigestMethod', _, DMContent} | Rest]) ->
+    [
+        {'ds:DigestMethod', [{'Algorithm', "http://www.w3.org/2001/04/xmlenc#sha512"}], DMContent}
+        | Rest
+    ];
+replace_digest_method_elem([H | T]) ->
+    [H | replace_digest_method_elem(T)].
 
 %%%%%%%%%%%%%%%%%%%%%%%
 %%% INTEROP SMOKE GROUP TESTS

--- a/test/signerl_cert_helpers.erl
+++ b/test/signerl_cert_helpers.erl
@@ -13,6 +13,7 @@
     signer_rsa_cert_path/0,
     signer_ecdsa_key_path/0,
     signer_ecdsa_cert_path/0,
+    high_serial_cert_path/0,
     load_private_key/1,
     load_cert/1,
     load_cert_chain/0,
@@ -98,6 +99,7 @@ signer_rsa_key_path() -> path("signer_rsa.key.pem").
 signer_rsa_cert_path() -> path("signer_rsa.cert.pem").
 signer_ecdsa_key_path() -> path("signer_ecdsa.key.pem").
 signer_ecdsa_cert_path() -> path("signer_ecdsa.cert.pem").
+high_serial_cert_path() -> path("high_serial.cert.pem").
 
 load_private_key(Path) ->
     decode_single_pem_entry(Path).

--- a/test/signerl_signed_properties_SUITE.erl
+++ b/test/signerl_signed_properties_SUITE.erl
@@ -9,6 +9,19 @@ suite() ->
 all() ->
     [
         extract_accepts_optional_signed_signature_properties,
+        extract_accepts_signing_certificate_v2_with_issuer_serial,
+        extract_accepts_signing_certificate_v2_without_issuer_serial,
+        extract_returns_error_with_empty_signing_certificate_v2,
+        extract_returns_error_with_missing_cert_digest,
+        extract_returns_error_with_invalid_digest_value,
+        extract_returns_error_with_duplicate_signing_certificate_v2,
+        extract_returns_error_with_missing_digest_method,
+        extract_accepts_binary_digest_value,
+        extract_returns_error_with_non_byte_list_digest_value,
+        extract_returns_error_with_non_text_digest_value,
+        extract_returns_error_with_empty_binary_digest_value,
+        extract_returns_error_with_invalid_base64_digest_value,
+        extract_ignores_invalid_base64_issuer_serial_v2,
         extract_ignores_unknown_signed_signature_properties,
         extract_accepts_binary_signing_time,
         extract_returns_error_with_non_byte_list_signing_time,
@@ -17,11 +30,45 @@ all() ->
         extract_returns_error_without_signing_time
     ].
 
+valid_signing_certificate_v2_element() ->
+    DigestB64 = binary_to_list(base64:encode(crypto:hash(sha256, <<"test-cert-der">>))),
+    IssuerSerialB64 = binary_to_list(base64:encode(<<"fake-issuer-serial">>)),
+    cert_v2_with_issuer(DigestB64, IssuerSerialB64).
+
+valid_signing_certificate_v2_no_issuer() ->
+    DigestB64 = binary_to_list(base64:encode(crypto:hash(sha256, <<"test-cert-der">>))),
+    {'xades:SigningCertificateV2', [], [
+        {'xades:Cert', [], [cert_digest_element(DigestB64)]}
+    ]}.
+
+cert_digest_element(DigestB64) ->
+    {'xades:CertDigest', [], [
+        {'ds:DigestMethod', [{'Algorithm', "http://www.w3.org/2001/04/xmlenc#sha256"}], []},
+        {'ds:DigestValue', [], [DigestB64]}
+    ]}.
+
+cert_v2_with_issuer(DigestB64, IssuerSerialB64) ->
+    {'xades:SigningCertificateV2', [], [
+        {'xades:Cert', [], [
+            cert_digest_element(DigestB64),
+            {'xades:IssuerSerialV2', [], [IssuerSerialB64]}
+        ]}
+    ]}.
+
+signature_with_cert_v2(CertV2) ->
+    test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        CertV2
+    ]).
+
 extract_accepts_optional_signed_signature_properties(_Config) ->
+    CertV2 = valid_signing_certificate_v2_element(),
+    ExpectedDigest = crypto:hash(sha256, <<"test-cert-der">>),
+    ExpectedIssuerSerial = <<"fake-issuer-serial">>,
     SignatureElement = test_helpers:signature_element([
         {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
         {'xades:SigningCertificate', [], []},
-        {'xades:SigningCertificateV2', [], []},
+        CertV2,
         {'xades:SignaturePolicyIdentifier', [], []},
         {'xades:SignatureProductionPlace', [], []},
         {'xades:SignerRole', [], []}
@@ -30,13 +77,212 @@ extract_accepts_optional_signed_signature_properties(_Config) ->
         {ok, #{
             signing_time => <<"2026-01-01T00:00:00Z">>,
             signing_certificate => present,
-            signing_certificate_v2 => present,
+            signing_certificate_v2 => #{
+                digest_method => "http://www.w3.org/2001/04/xmlenc#sha256",
+                digest_value => ExpectedDigest,
+                issuer_serial_v2 => ExpectedIssuerSerial
+            },
             signature_policy_identifier => present,
             signature_production_place => present,
             signer_role => present
         }},
         signerl_signed_properties:extract(SignatureElement)
     ).
+
+extract_accepts_signing_certificate_v2_with_issuer_serial(_Config) ->
+    CertV2 = valid_signing_certificate_v2_element(),
+    ExpectedDigest = crypto:hash(sha256, <<"test-cert-der">>),
+    ExpectedIssuerSerial = <<"fake-issuer-serial">>,
+    SignatureElement = signature_with_cert_v2(CertV2),
+    {ok, Props} = signerl_signed_properties:extract(SignatureElement),
+    ?assertEqual(
+        #{
+            digest_method => "http://www.w3.org/2001/04/xmlenc#sha256",
+            digest_value => ExpectedDigest,
+            issuer_serial_v2 => ExpectedIssuerSerial
+        },
+        maps:get(signing_certificate_v2, Props)
+    ).
+
+extract_accepts_signing_certificate_v2_without_issuer_serial(_Config) ->
+    CertV2 = valid_signing_certificate_v2_no_issuer(),
+    ExpectedDigest = crypto:hash(sha256, <<"test-cert-der">>),
+    SignatureElement = signature_with_cert_v2(CertV2),
+    {ok, Props} = signerl_signed_properties:extract(SignatureElement),
+    ?assertEqual(
+        #{
+            digest_method => "http://www.w3.org/2001/04/xmlenc#sha256",
+            digest_value => ExpectedDigest
+        },
+        maps:get(signing_certificate_v2, Props)
+    ).
+
+extract_returns_error_with_empty_signing_certificate_v2(_Config) ->
+    SignatureElement = test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        {'xades:SigningCertificateV2', [], []}
+    ]),
+    ?assertEqual(
+        {error, invalid_signing_certificate_v2},
+        signerl_signed_properties:extract(SignatureElement)
+    ).
+
+extract_returns_error_with_missing_cert_digest(_Config) ->
+    SignatureElement = test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        {'xades:SigningCertificateV2', [], [
+            {'xades:Cert', [], [
+                {'xades:IssuerSerialV2', [], ["AQID"]}
+            ]}
+        ]}
+    ]),
+    ?assertEqual(
+        {error, invalid_signing_certificate_v2},
+        signerl_signed_properties:extract(SignatureElement)
+    ).
+
+extract_returns_error_with_invalid_digest_value(_Config) ->
+    SignatureElement = test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        {'xades:SigningCertificateV2', [], [
+            {'xades:Cert', [], [
+                {'xades:CertDigest', [], [
+                    {'ds:DigestMethod', [{'Algorithm', "http://www.w3.org/2001/04/xmlenc#sha256"}],
+                        []},
+                    {'ds:DigestValue', [], []}
+                ]}
+            ]}
+        ]}
+    ]),
+    ?assertEqual(
+        {error, invalid_signing_certificate_v2},
+        signerl_signed_properties:extract(SignatureElement)
+    ).
+
+extract_returns_error_with_duplicate_signing_certificate_v2(_Config) ->
+    CertV2 = valid_signing_certificate_v2_element(),
+    SignatureElement = test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        CertV2,
+        CertV2
+    ]),
+    ?assertEqual(
+        {error, duplicate_property},
+        signerl_signed_properties:extract(SignatureElement)
+    ).
+
+extract_returns_error_with_missing_digest_method(_Config) ->
+    DigestB64 = binary_to_list(base64:encode(crypto:hash(sha256, <<"test">>))),
+    SignatureElement = test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        {'xades:SigningCertificateV2', [], [
+            {'xades:Cert', [], [
+                {'xades:CertDigest', [], [
+                    {'ds:DigestValue', [], [DigestB64]}
+                ]}
+            ]}
+        ]}
+    ]),
+    ?assertEqual(
+        {error, invalid_signing_certificate_v2},
+        signerl_signed_properties:extract(SignatureElement)
+    ).
+
+extract_accepts_binary_digest_value(_Config) ->
+    DigestB64 = base64:encode(crypto:hash(sha256, <<"test">>)),
+    IssuerSerialB64 = base64:encode(<<"fake-issuer-serial">>),
+    CertV2Element = cert_v2_with_issuer(DigestB64, IssuerSerialB64),
+    SignatureElement = signature_with_cert_v2(CertV2Element),
+    {ok, Props} = signerl_signed_properties:extract(SignatureElement),
+    CertV2Props = maps:get(signing_certificate_v2, Props),
+    ?assertEqual(crypto:hash(sha256, <<"test">>), maps:get(digest_value, CertV2Props)),
+    ?assertEqual(<<"fake-issuer-serial">>, maps:get(issuer_serial_v2, CertV2Props)).
+
+extract_returns_error_with_non_byte_list_digest_value(_Config) ->
+    SignatureElement = test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        {'xades:SigningCertificateV2', [], [
+            {'xades:Cert', [], [
+                {'xades:CertDigest', [], [
+                    {'ds:DigestMethod', [{'Algorithm', "http://www.w3.org/2001/04/xmlenc#sha256"}],
+                        []},
+                    {'ds:DigestValue', [], [[65, {invalid}]]}
+                ]}
+            ]}
+        ]}
+    ]),
+    ?assertEqual(
+        {error, invalid_signing_certificate_v2},
+        signerl_signed_properties:extract(SignatureElement)
+    ).
+
+extract_returns_error_with_non_text_digest_value(_Config) ->
+    SignatureElement = test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        {'xades:SigningCertificateV2', [], [
+            {'xades:Cert', [], [
+                {'xades:CertDigest', [], [
+                    {'ds:DigestMethod', [{'Algorithm', "http://www.w3.org/2001/04/xmlenc#sha256"}],
+                        []},
+                    {'ds:DigestValue', [], [12345]}
+                ]}
+            ]}
+        ]}
+    ]),
+    ?assertEqual(
+        {error, invalid_signing_certificate_v2},
+        signerl_signed_properties:extract(SignatureElement)
+    ).
+
+extract_returns_error_with_empty_binary_digest_value(_Config) ->
+    SignatureElement = test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        {'xades:SigningCertificateV2', [], [
+            {'xades:Cert', [], [
+                {'xades:CertDigest', [], [
+                    {'ds:DigestMethod', [{'Algorithm', "http://www.w3.org/2001/04/xmlenc#sha256"}],
+                        []},
+                    {'ds:DigestValue', [], [<<>>]}
+                ]}
+            ]}
+        ]}
+    ]),
+    ?assertEqual(
+        {error, invalid_signing_certificate_v2},
+        signerl_signed_properties:extract(SignatureElement)
+    ).
+
+extract_returns_error_with_invalid_base64_digest_value(_Config) ->
+    SignatureElement = test_helpers:signature_element([
+        {'xades:SigningTime', [], ["2026-01-01T00:00:00Z"]},
+        {'xades:SigningCertificateV2', [], [
+            {'xades:Cert', [], [
+                {'xades:CertDigest', [], [
+                    {'ds:DigestMethod', [{'Algorithm', "http://www.w3.org/2001/04/xmlenc#sha256"}],
+                        []},
+                    {'ds:DigestValue', [], ["not valid base64!!!"]}
+                ]}
+            ]}
+        ]}
+    ]),
+    ?assertEqual(
+        {error, invalid_signing_certificate_v2},
+        signerl_signed_properties:extract(SignatureElement)
+    ).
+
+extract_ignores_invalid_base64_issuer_serial_v2(_Config) ->
+    DigestB64 = binary_to_list(base64:encode(crypto:hash(sha256, <<"test">>))),
+    CertV2 =
+        {'xades:SigningCertificateV2', [], [
+            {'xades:Cert', [], [
+                cert_digest_element(DigestB64),
+                {'xades:IssuerSerialV2', [], ["not valid base64!!!"]}
+            ]}
+        ]},
+    SignatureElement = signature_with_cert_v2(CertV2),
+    {ok, Props} = signerl_signed_properties:extract(SignatureElement),
+    CertV2Props = maps:get(signing_certificate_v2, Props),
+    ?assertNot(maps:is_key(issuer_serial_v2, CertV2Props)).
 
 extract_ignores_unknown_signed_signature_properties(_Config) ->
     SignatureElement = test_helpers:signature_element([


### PR DESCRIPTION
Closes #36

## Summary

Adds the `xades:SigningCertificateV2` element to the signing and verification pipeline (Phase 2, Task 1 of XAdES Baseline-B).

### Changes

- **New `signerl_cert` module** — `cert_digest_base64/2` and `issuer_serial_v2_base64/1` with manual DER encoding for IssuerSerial (RFC 5035, OTP lacks this ASN.1 type)
- **`signerl_signature`** — emits `SigningCertificateV2` when certificate DER is provided via `sign/4`; omitted for `sign/3` (backward compat)
- **`signerl_signed_properties`** — full structural validation of `SigningCertificateV2` (digest method, digest value, optional IssuerSerialV2)
- **`signerl_verify`** — cross-checks cert digest between `SigningCertificateV2` and `KeyInfo` certificate; passes gracefully when either is absent

### Quality Gates

| Gate | Result |
|------|--------|
| `rebar3 eunit` | 14 tests, 0 failures |
| `rebar3 ct` | 149 tests, 0 failures |
| `rebar3 as test cover` | **100%** total coverage |
| `rebar3 flint` | Clean |
| `rebar3 dialyzer` | Clean |
